### PR TITLE
Ensure all tool windows honor Visual Studio theme

### DIFF
--- a/AxialSqlTools/Commands/FormatQueryDialog/FormatOptionsDialog.xaml
+++ b/AxialSqlTools/Commands/FormatQueryDialog/FormatOptionsDialog.xaml
@@ -1,7 +1,10 @@
 ﻿<Window x:Class="AxialSqlTools.FormatOptionsDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
         Title="Query Format Options" SizeToContent="WidthAndHeight"
+        Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+        Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
         WindowStartupLocation="CenterOwner" ResizeMode="NoResize">
     <DockPanel Margin="12" MinWidth="520">
 

--- a/AxialSqlTools/DataImport/DataImportWindowControl.xaml
+++ b/AxialSqlTools/DataImport/DataImportWindowControl.xaml
@@ -3,6 +3,9 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+             Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+             Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
              mc:Ignorable="d"
              d:DesignWidth="600"
              d:DesignHeight="420">

--- a/AxialSqlTools/GridToEmail/ToolWindowGridToEmailControl.xaml
+++ b/AxialSqlTools/GridToEmail/ToolWindowGridToEmailControl.xaml
@@ -4,6 +4,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+             Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+             Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
              mc:Ignorable="d" 
              Name="MyToolWindow"
              FontSize="14">

--- a/AxialSqlTools/HealthDashboards/HealthDashboard_ServerControl.xaml
+++ b/AxialSqlTools/HealthDashboards/HealthDashboard_ServerControl.xaml
@@ -5,6 +5,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:oxy="http://oxyplot.org/wpf"
+             Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+             Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
              mc:Ignorable="d"
              d:DesignHeight="500" d:DesignWidth="1000"
              x:Name="MyToolWindow">

--- a/AxialSqlTools/HealthDashboards/HealthDashboard_ServersControl.xaml
+++ b/AxialSqlTools/HealthDashboards/HealthDashboard_ServersControl.xaml
@@ -4,6 +4,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+             Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+             Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
              mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="1000"
              Name="MyToolWindow">

--- a/AxialSqlTools/SchemaCompare/SchemaCompareWindowControl.xaml
+++ b/AxialSqlTools/SchemaCompare/SchemaCompareWindowControl.xaml
@@ -2,7 +2,10 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+             Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
              mc:Ignorable="d" MinWidth="900" MinHeight="600">
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />

--- a/AxialSqlTools/SyncToGitHub/DatabaseScripterToolWindowControl.xaml
+++ b/AxialSqlTools/SyncToGitHub/DatabaseScripterToolWindowControl.xaml
@@ -3,6 +3,9 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+             Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+             Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
              mc:Ignorable="d"
              d:DesignWidth="600"
              Name="MyToolWindow">

--- a/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
+++ b/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
@@ -3,7 +3,10 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	mc:Ignorable="d"
+             xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+	Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+             Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
+             mc:Ignorable="d"
 	Name="MyToolWindow">
     
     <DockPanel>


### PR DESCRIPTION
## Summary
- add the Visual Studio shell namespace and dynamic background/foreground resources to the remaining tool windows and dialogs
- make sure every window now uses the VS theme brushes so text remains legible in the dark theme

## Testing
- Not run (dotnet CLI is unavailable in the container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a2dd39de083339a761b014fede612)