### PR TITLE
Improve comment interleaving layout

### DIFF
--- a/AxialSqlTools/Modules/TsqlFormatterCommentInterleaver.cs
+++ b/AxialSqlTools/Modules/TsqlFormatterCommentInterleaver.cs
@@ -93,7 +93,10 @@ public static class TsqlFormatterCommentInterleaver
             // Anchor to the *next statement header* if the immediate next code token is ';'
             int anchorOrig = FindAnchorAfterComments(orig, k);
 
-            var clusterText = startsNewLine ? chunk.ToString() : chunk.ToString().TrimEnd();
+            var rawCluster = chunk.ToString();
+            var clusterText = startsNewLine
+                ? rawCluster
+                : (HasNewline(rawCluster) ? rawCluster : rawCluster.TrimEnd());
             var cluster = new CommentCluster(clusterText, startsNewLine, blankLinesBefore);
 
             if (!startsNewLine)

--- a/AxialSqlTools/Modules/TsqlFormatterCommentInterleaver.cs
+++ b/AxialSqlTools/Modules/TsqlFormatterCommentInterleaver.cs
@@ -53,8 +53,9 @@ public static class TsqlFormatterCommentInterleaver
             mapOrigToFmt[origCodeIdx[iOrigKey]] = fmtCodeIdx[iFmtKey];
         }
 
-        // Collect comments from original and schedule injection BEFORE a formatted code token.
+        // Collect comments from original and schedule injection BEFORE/AFTER a formatted code token.
         var injectBeforeFmtIndex = new Dictionary<int, List<CommentCluster>>();
+        var injectAfterFmtIndex = new Dictionary<int, List<CommentCluster>>();
         var eofComments = new List<CommentCluster>();
 
         // Helper to add a comment to a bucket
@@ -62,6 +63,13 @@ public static class TsqlFormatterCommentInterleaver
         {
             if (!injectBeforeFmtIndex.TryGetValue(fmtIndex, out var list))
                 injectBeforeFmtIndex[fmtIndex] = list = new List<CommentCluster>();
+            list.Add(cluster);
+        }
+
+        void ScheduleAfter(int fmtIndex, CommentCluster cluster)
+        {
+            if (!injectAfterFmtIndex.TryGetValue(fmtIndex, out var list))
+                injectAfterFmtIndex[fmtIndex] = list = new List<CommentCluster>();
             list.Add(cluster);
         }
 
@@ -85,7 +93,18 @@ public static class TsqlFormatterCommentInterleaver
             // Anchor to the *next statement header* if the immediate next code token is ';'
             int anchorOrig = FindAnchorAfterComments(orig, k);
 
-            var cluster = new CommentCluster(chunk.ToString(), startsNewLine, blankLinesBefore);
+            var clusterText = startsNewLine ? chunk.ToString() : chunk.ToString().TrimEnd();
+            var cluster = new CommentCluster(clusterText, startsNewLine, blankLinesBefore);
+
+            if (!startsNewLine)
+            {
+                int prevCode = PrevIndex(orig, i, IsCodeToken);
+                if (prevCode >= 0 && mapOrigToFmt.TryGetValue(prevCode, out int prevFmtIndex))
+                {
+                    ScheduleAfter(prevFmtIndex, cluster);
+                    continue;
+                }
+            }
 
             if (anchorOrig >= 0 && mapOrigToFmt.TryGetValue(anchorOrig, out int fmtIndex))
                 Schedule(fmtIndex, cluster);
@@ -109,20 +128,20 @@ public static class TsqlFormatterCommentInterleaver
             {
                 foreach (var c in toInject)
                 {
-                    if (c.StartsNewLine)
-                    {
-                        // We want: at least (1 + blankLinesBefore) newlines before the comment.
-                        int required = 1 + c.BlankLinesBefore;
-                        int have = TrailingNewlines(sb);
-                        for (int add = have; add < required; add++)
-                            sb.Append(Environment.NewLine);
-                    }
-                    sb.Append(c.Text);
+                    AppendWithLayout(sb, c);
                 }
             }
 
             sb.Append(fmt[jCode].Text);
             cur++;
+
+            if (injectAfterFmtIndex.TryGetValue(jCode, out var toInjectAfter))
+            {
+                foreach (var c in toInjectAfter)
+                {
+                    AppendWithLayout(sb, c);
+                }
+            }
         }
 
         while (cur < fmt.Count) { sb.Append(fmt[cur].Text); cur++; }
@@ -154,6 +173,13 @@ public static class TsqlFormatterCommentInterleaver
         for (int i = 0; i < tokens.Count; i++)
             if (pred(tokens[i])) list.Add(i);
         return list;
+    }
+
+    private static int PrevIndex(IList<TSqlParserToken> tokens, int start, Func<TSqlParserToken, bool> pred)
+    {
+        for (int i = start; i >= 0; i--)
+            if (pred(tokens[i])) return i;
+        return -1;
     }
 
     private static int NextIndex(IList<TSqlParserToken> tokens, int start, Func<TSqlParserToken, bool> pred)
@@ -207,6 +233,27 @@ public static class TsqlFormatterCommentInterleaver
         t.TokenType == TSqlTokenType.WhiteSpace ||
         t.TokenType == TSqlTokenType.SingleLineComment ||
         t.TokenType == TSqlTokenType.MultilineComment;
+
+    private static bool EndsWithWhitespace(StringBuilder sb) =>
+        sb.Length > 0 && char.IsWhiteSpace(sb[sb.Length - 1]);
+
+    private static void AppendWithLayout(StringBuilder sb, CommentCluster cluster)
+    {
+        if (cluster.StartsNewLine)
+        {
+            // We want: at least (1 + blankLinesBefore) newlines before the comment.
+            int required = 1 + cluster.BlankLinesBefore;
+            int have = TrailingNewlines(sb);
+            for (int add = have; add < required; add++)
+                sb.Append(Environment.NewLine);
+        }
+        else if (!EndsWithWhitespace(sb))
+        {
+            sb.Append(' ');
+        }
+
+        sb.Append(cluster.Text);
+    }
 
 
     // Normalized comparison key for LCS: (TokenType, normalized text).


### PR DESCRIPTION
## Summary
- ensure inline comments are attached to their preceding code tokens to keep single-line comments on the same line
- trim trailing whitespace from inline comment clusters and centralize layout handling to avoid extra blank space
- support injecting comments both before and after formatted tokens while preserving intended blank lines

## Testing
- Not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a5952e15c83339a4b554aa13c6148)