### PR TITLE
Add 15-minute performance metrics dashboard

### DIFF
--- a/AxialSqlTools/HealthDashboards/HealthDashboard_ServerControl.xaml
+++ b/AxialSqlTools/HealthDashboards/HealthDashboard_ServerControl.xaml
@@ -272,6 +272,26 @@
                 </Grid>
             </TabItem>
 
+            <!-- TAB 4: Performance Metrics (15 minutes) -->
+            <TabItem Header="Performance (15m)">
+                <ScrollViewer Margin="0" VerticalScrollBarVisibility="Auto">
+                    <UniformGrid Columns="3" Rows="4" Margin="5" HorizontalAlignment="Stretch" VerticalAlignment="Top">
+                        <oxy:PlotView x:Name="PerfChart_CpuUtilization" Height="250" Margin="5"/>
+                        <oxy:PlotView x:Name="PerfChart_UserConnections" Height="250" Margin="5"/>
+                        <oxy:PlotView x:Name="PerfChart_BatchRequests" Height="250" Margin="5"/>
+                        <oxy:PlotView x:Name="PerfChart_SqlCompilations" Height="250" Margin="5"/>
+                        <oxy:PlotView x:Name="PerfChart_PageLifeExpectancy" Height="250" Margin="5"/>
+                        <oxy:PlotView x:Name="PerfChart_PageReads" Height="250" Margin="5"/>
+                        <oxy:PlotView x:Name="PerfChart_PageWrites" Height="250" Margin="5"/>
+                        <oxy:PlotView x:Name="PerfChart_LogFlushes" Height="250" Margin="5"/>
+                        <oxy:PlotView x:Name="PerfChart_Transactions" Height="250" Margin="5"/>
+                        <oxy:PlotView x:Name="PerfChart_LockWaits" Height="250" Margin="5"/>
+                        <oxy:PlotView x:Name="PerfChart_MemoryGrantsPending" Height="250" Margin="5"/>
+                        <oxy:PlotView x:Name="PerfChart_TotalServerMemory" Height="250" Margin="5"/>
+                    </UniformGrid>
+                </ScrollViewer>
+            </TabItem>
+
         </TabControl>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- add a new Performance tab with 12 charts to visualize key SQL Server health counters over a rolling 15-minute window
- record per-sample performance history in the server dashboard to keep charts current without retaining stale data
- extend the metrics service to gather additional performance counter deltas for I/O, transactions, waits, and memory grant pressure

## Testing
- dotnet build AxialSqlTools.sln *(fails: `dotnet` not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ccf1a1d788333b8de50f68589a1ad)