### PR TITLE
Implement formatting option to align SELECT fields after DISTINCT/TOP

### DIFF
--- a/AxialSqlTools/Commands/FormatQueryDialog/FormatOptionsDialog.xaml
+++ b/AxialSqlTools/Commands/FormatQueryDialog/FormatOptionsDialog.xaml
@@ -69,6 +69,10 @@
                 Content="Break sproc definition parameters per line"
                 Checked="formatSetting_Checked"
                 Unchecked="formatSetting_Unchecked"/>
+            <CheckBox x:Name="BreakSelectFieldsAfterTopAndUnindent" Margin="5"
+                Content="Break SELECT fields after DISTINCT/TOP"
+                Checked="formatSetting_Checked"
+                Unchecked="formatSetting_Unchecked"/>
         </UniformGrid>
 
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal"

--- a/AxialSqlTools/Commands/FormatQueryDialog/FormatOptionsDialog.xaml.cs
+++ b/AxialSqlTools/Commands/FormatQueryDialog/FormatOptionsDialog.xaml.cs
@@ -27,6 +27,7 @@ namespace AxialSqlTools
             UnindentBeginEndBlocks.IsChecked = Settings.unindentBeginEndBlocks;
             BreakVariableDefinitionsPerLine.IsChecked = Settings.breakVariableDefinitionsPerLine;
             BreakSprocDefinitionParametersPerLine.IsChecked = Settings.breakSprocDefinitionParametersPerLine;
+            BreakSelectFieldsAfterTopAndUnindent.IsChecked = Settings.breakSelectFieldsAfterTopAndUnindent;
         }
 
         private void formatSetting_Checked(object sender, RoutedEventArgs e)
@@ -51,6 +52,7 @@ namespace AxialSqlTools
             UnindentBeginEndBlocks.IsChecked = value;
             BreakVariableDefinitionsPerLine.IsChecked = value;
             BreakSprocDefinitionParametersPerLine.IsChecked = value;
+            BreakSelectFieldsAfterTopAndUnindent.IsChecked = value;
         }
 
         private void CheckAllOptions_Click(object sender, RoutedEventArgs e)
@@ -76,6 +78,7 @@ namespace AxialSqlTools
             Settings.unindentBeginEndBlocks = UnindentBeginEndBlocks.IsChecked == true;
             Settings.breakVariableDefinitionsPerLine = BreakVariableDefinitionsPerLine.IsChecked == true;
             Settings.breakSprocDefinitionParametersPerLine = BreakSprocDefinitionParametersPerLine.IsChecked == true;
+            Settings.breakSelectFieldsAfterTopAndUnindent = BreakSelectFieldsAfterTopAndUnindent.IsChecked == true;
         }
 
         private void Ok_Click(object sender, RoutedEventArgs e)

--- a/AxialSqlTools/Modules/TsqlFormatter.cs
+++ b/AxialSqlTools/Modules/TsqlFormatter.cs
@@ -840,7 +840,9 @@ namespace AxialSqlTools
             if (formatSettings.breakSelectFieldsAfterTopAndUnindent)
             {
                 var tokens = sqlFragment.ScriptTokenStream;
-                const int indentSpacesBetweenSelectAndFields = 7;
+                // Keep field indentation predictable: always one indent level past the SELECT line.
+                // Prefer tabs when the surrounding block already uses tabs; otherwise fall back to 4 spaces.
+                string indentAfterSelect = "\t";
 
                 foreach (var qs in visitor.SelectsWithTopOrDistinct)
                 {
@@ -858,7 +860,8 @@ namespace AxialSqlTools
                             : ws;
                     }
 
-                    string fieldIndent = baseIndent + new string(' ', indentSpacesBetweenSelectAndFields);
+                    string indentUnit = baseIndent.Contains("\t") ? indentAfterSelect : new string(' ', 4);
+                    string fieldIndent = baseIndent + indentUnit;
 
                     void ReplaceWhitespaceWithIndent(int idx, string indent)
                     {

--- a/AxialSqlTools/Modules/TsqlFormatter.cs
+++ b/AxialSqlTools/Modules/TsqlFormatter.cs
@@ -880,11 +880,30 @@ namespace AxialSqlTools
                     if (string.IsNullOrEmpty(ws))
                         return ws;
 
-                    while (ws.Contains("\r\n\r\n"))
+                    var lines = ws.Split(new[] { "\r\n" }, StringSplitOptions.None);
+                    List<string> compact = new List<string>();
+                    bool previousBlank = false;
+
+                    foreach (var line in lines)
                     {
-                        ws = ws.Replace("\r\n\r\n", "\r\n");
+                        bool isBlank = string.IsNullOrWhiteSpace(line);
+
+                        if (isBlank)
+                        {
+                            if (previousBlank)
+                                continue;
+
+                            compact.Add(string.Empty);
+                        }
+                        else
+                        {
+                            compact.Add(line);
+                        }
+
+                        previousBlank = isBlank;
                     }
-                    return ws;
+
+                    return string.Join("\r\n", compact);
                 }
 
                 void CollapseRangeWhitespace(int startIdx, int endIdx)

--- a/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
+++ b/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
@@ -363,9 +363,8 @@
                               Content="Break sproc definition parameters per line" 
                               Checked="formatSetting_Checked"
                               Unchecked="formatSetting_Unchecked"/>
-                        <!-- TODO -->
-                        <CheckBox x:Name="BreakSelectFieldsAfterTopAndUnindent" Margin="5" Visibility="Hidden"
-                              Content="Break SELECT fields after TOP and unindent" 
+                        <CheckBox x:Name="BreakSelectFieldsAfterTopAndUnindent" Margin="5"
+                              Content="Break SELECT fields after DISTINCT/TOP"
                               Checked="formatSetting_Checked"
                               Unchecked="formatSetting_Unchecked"/>
 

--- a/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml.cs
+++ b/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml.cs
@@ -102,9 +102,9 @@ as select 1;
                 BreakSprocParametersPerLine.IsChecked = tsqlCodeFormatSettings.breakSprocParametersPerLine;
                 UppercaseBuiltInFunctions.IsChecked = tsqlCodeFormatSettings.uppercaseBuiltInFunctions;
                 UnindentBeginEndBlocks.IsChecked = tsqlCodeFormatSettings.unindentBeginEndBlocks;
-                BreakVariableDefinitionsPerLine.IsChecked = tsqlCodeFormatSettings.breakVariableDefinitionsPerLine;  
+                BreakVariableDefinitionsPerLine.IsChecked = tsqlCodeFormatSettings.breakVariableDefinitionsPerLine;
                 BreakSprocDefinitionParametersPerLine.IsChecked = tsqlCodeFormatSettings.breakSprocDefinitionParametersPerLine;
-                // BreakSelectFieldsAfterTopAndUnindent.IsChecked = tsqlCodeFormatSettings.breakSelectFieldsAfterTopAndUnindent;
+                BreakSelectFieldsAfterTopAndUnindent.IsChecked = tsqlCodeFormatSettings.breakSelectFieldsAfterTopAndUnindent;
 
                 OpenAiApiKey.Password = SettingsManager.GetOpenAiApiKey();
 
@@ -327,7 +327,7 @@ as select 1;
                 unindentBeginEndBlocks = UnindentBeginEndBlocks.IsChecked.GetValueOrDefault(false),
                 breakVariableDefinitionsPerLine = BreakVariableDefinitionsPerLine.IsChecked.GetValueOrDefault(false),
                 breakSprocDefinitionParametersPerLine = BreakSprocDefinitionParametersPerLine.IsChecked.GetValueOrDefault(false),
-                // breakSelectFieldsAfterTopAndUnindent = BreakSelectFieldsAfterTopAndUnindent.IsChecked.GetValueOrDefault(false)
+                breakSelectFieldsAfterTopAndUnindent = BreakSelectFieldsAfterTopAndUnindent.IsChecked.GetValueOrDefault(false)
             };
 
             SettingsManager.SaveTSqlCodeFormatSettings(settings);
@@ -515,7 +515,7 @@ as select 1;
                 unindentBeginEndBlocks = UnindentBeginEndBlocks.IsChecked.GetValueOrDefault(false),
                 breakVariableDefinitionsPerLine = BreakVariableDefinitionsPerLine.IsChecked.GetValueOrDefault(false),
                 breakSprocDefinitionParametersPerLine = BreakSprocDefinitionParametersPerLine.IsChecked.GetValueOrDefault(false),
-                // breakSelectFieldsAfterTopAndUnindent = BreakSelectFieldsAfterTopAndUnindent.IsChecked.GetValueOrDefault(false)
+                breakSelectFieldsAfterTopAndUnindent = BreakSelectFieldsAfterTopAndUnindent.IsChecked.GetValueOrDefault(false)
             };
 
             FormattedQueryPreview.Text = TSqlFormatter.FormatCode(SourceQueryPreview.Text, settings);


### PR DESCRIPTION
## Summary
- add formatting logic to align SELECT fields after DISTINCT/TOP with consistent indentation and FROM alignment
- surface the new SELECT alignment option in both the quick format dialog and settings UI

## Testing
- dotnet build AxialSqlTools.sln *(fails: dotnet not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69223b839558833381611910d9709733)