### PR TITLE
Add double-click selection for N-prefixed strings (no luck so far)

### DIFF
--- a/AxialSqlTools/AxialSqlTools.csproj
+++ b/AxialSqlTools/AxialSqlTools.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Modules\GoogleSheetsExport.cs" />
     <Compile Include="Modules\GridAccess.cs" />
     <Compile Include="Modules\KeypressCommandFilter.cs" />
+    <Compile Include="Modules\SqlStringSelectionMouseProcessor.cs" />
     <Compile Include="Modules\MetricsService.cs" />
     <Compile Include="Modules\ScriptFactoryAccess.cs" />
     <Compile Include="Modules\SettingsManager.cs" />

--- a/AxialSqlTools/Modules/KeypressCommandFilter.cs
+++ b/AxialSqlTools/Modules/KeypressCommandFilter.cs
@@ -163,6 +163,28 @@ namespace AxialSqlTools
             return nextTextViewFilter?.GetWordExtent(iLine, iIdx, dwFlags, pSpan) ?? VSConstants.E_FAIL;
         }
 
+        public int GetPairExtents(int iLine, int iIndex, TextSpan[] pts)
+        {
+            if (nextTextViewFilter != null)
+            {
+                return nextTextViewFilter.GetPairExtents(iLine, iIndex, pts);
+            }
+
+            return VSConstants.E_NOTIMPL;
+        }
+
+        public int GetDataTipText(TextSpan[] pSpan, out string pbstrText)
+        {
+            pbstrText = null;
+
+            if (nextTextViewFilter != null)
+            {
+                return nextTextViewFilter.GetDataTipText(pSpan, out pbstrText);
+            }
+
+            return VSConstants.E_NOTIMPL;
+        }
+
         private static bool TryGetQuotedStringSpan(string lineText, int position, out int startIndex, out int endIndex)
         {
             startIndex = -1;

--- a/AxialSqlTools/Modules/KeypressCommandFilter.cs
+++ b/AxialSqlTools/Modules/KeypressCommandFilter.cs
@@ -142,7 +142,7 @@ namespace AxialSqlTools
                 return nextTextViewFilter?.GetWordExtent(iLine, iIdx, dwFlags, pSpan) ?? VSConstants.E_FAIL;
             }
 
-            bool isDoubleClick = (dwFlags & (uint)WORDEXTFLAGS.WORDEXT_DBLCLICK) != 0;
+            bool isDoubleClick = (WORDEXTFLAGS)dwFlags == WORDEXTFLAGS.WORDEXT_FINDWORD;
 
             if (isDoubleClick && textView.GetBuffer(out IVsTextLines textLines) == VSConstants.S_OK)
             {

--- a/AxialSqlTools/Modules/KeypressCommandFilter.cs
+++ b/AxialSqlTools/Modules/KeypressCommandFilter.cs
@@ -32,7 +32,14 @@ namespace AxialSqlTools
                 throw new Exception("Failed to add command filter");
             }
 
-            nextTextViewFilter = nextCommandTarget as IVsTextViewFilter;
+            if (textView != null && textView.AddTextViewFilter(this, out IVsTextViewFilter downstreamFilter) == VSConstants.S_OK)
+            {
+                nextTextViewFilter = downstreamFilter;
+            }
+            else
+            {
+                nextTextViewFilter = nextCommandTarget as IVsTextViewFilter;
+            }
         }
 
         public int Exec(ref Guid cmdGroup, uint nCmdID, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)

--- a/AxialSqlTools/Modules/SqlStringSelectionMouseProcessor.cs
+++ b/AxialSqlTools/Modules/SqlStringSelectionMouseProcessor.cs
@@ -12,7 +12,9 @@ namespace AxialSqlTools
     [Export(typeof(IMouseProcessorProvider))]
     [Name("sql-string-double-click-selector")]
     [ContentType("text")]
-    [TextViewRole(PredefinedTextViewRoles.Document)]
+    [ContentType("code")]
+    [Order(Before = PredefinedMouseProcessorNames.WordSelection)]
+    [TextViewRole(PredefinedTextViewRoles.Editable)]
     public class SqlStringSelectionMouseProcessorProvider : IMouseProcessorProvider
     {
         public IMouseProcessor GetAssociatedProcessor(IWpfTextView wpfTextView)
@@ -69,6 +71,11 @@ namespace AxialSqlTools
 
         private SnapshotPoint? GetSnapshotAtCursor(MouseButtonEventArgs e)
         {
+            if (view.TextViewLines == null || view.TextViewLines.IsEmpty)
+            {
+                return null;
+            }
+
             Point cursorPosition = GetPositionInViewport(e);
             ITextViewLine textViewLine = view.TextViewLines.GetTextViewLineContainingYCoordinate(cursorPosition.Y);
 

--- a/AxialSqlTools/Modules/SqlStringSelectionMouseProcessor.cs
+++ b/AxialSqlTools/Modules/SqlStringSelectionMouseProcessor.cs
@@ -1,0 +1,143 @@
+using System;
+using System.ComponentModel.Composition;
+using System.Windows;
+using System.Windows.Input;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Formatting;
+using Microsoft.VisualStudio.Utilities;
+
+namespace AxialSqlTools
+{
+    [Export(typeof(IMouseProcessorProvider))]
+    [Name("sql-string-double-click-selector")]
+    [ContentType("text")]
+    [TextViewRole(PredefinedTextViewRoles.Document)]
+    public class SqlStringSelectionMouseProcessorProvider : IMouseProcessorProvider
+    {
+        public IMouseProcessor GetAssociatedProcessor(IWpfTextView wpfTextView)
+        {
+            return new SqlStringSelectionMouseProcessor(wpfTextView);
+        }
+    }
+
+    public class SqlStringSelectionMouseProcessor : MouseProcessorBase
+    {
+        private readonly IWpfTextView view;
+
+        public SqlStringSelectionMouseProcessor(IWpfTextView view)
+        {
+            this.view = view ?? throw new ArgumentNullException(nameof(view));
+        }
+
+        public override void PreprocessMouseLeftButtonDown(MouseButtonEventArgs e)
+        {
+            if (e.ChangedButton != MouseButton.Left)
+            {
+                return;
+            }
+
+            if (e.ClickCount != 2)
+            {
+                return;
+            }
+
+            if (Keyboard.Modifiers != ModifierKeys.None)
+            {
+                return;
+            }
+
+            if (SelectQuotedString(e))
+            {
+                e.Handled = true;
+            }
+        }
+
+        private bool SelectQuotedString(MouseButtonEventArgs e)
+        {
+            SnapshotPoint? snapshotPoint = GetSnapshotAtCursor(e);
+
+            if (snapshotPoint.HasValue && TryGetQuotedStringSpan(snapshotPoint.Value, out SnapshotSpan span))
+            {
+                view.Selection.Select(span, isReversed: false);
+                view.Caret.MoveTo(span.End);
+                return true;
+            }
+
+            return false;
+        }
+
+        private SnapshotPoint? GetSnapshotAtCursor(MouseButtonEventArgs e)
+        {
+            Point cursorPosition = GetPositionInViewport(e);
+            ITextViewLine textViewLine = view.TextViewLines.GetTextViewLineContainingYCoordinate(cursorPosition.Y);
+
+            if (textViewLine != null)
+            {
+                return textViewLine.GetBufferPositionFromXCoordinate(cursorPosition.X, true);
+            }
+
+            return null;
+        }
+
+        private Point GetPositionInViewport(MouseButtonEventArgs e)
+        {
+            Point relativePosition = e.GetPosition(view.VisualElement);
+            return new Point(relativePosition.X + view.ViewportLeft, relativePosition.Y + view.ViewportTop);
+        }
+
+        private bool TryGetQuotedStringSpan(SnapshotPoint point, out SnapshotSpan span)
+        {
+            string text = point.Snapshot.GetText();
+            int position = point.Position;
+
+            bool insideString = false;
+            int stringStart = -1;
+
+            for (int index = 0; index < text.Length; index++)
+            {
+                char current = text[index];
+
+                if (current == '\'')
+                {
+                    if (insideString)
+                    {
+                        if (index + 1 < text.Length && text[index + 1] == '\'')
+                        {
+                            index++;
+                            continue;
+                        }
+
+                        int stringEnd = index;
+                        if (position >= stringStart && position <= stringEnd)
+                        {
+                            span = new SnapshotSpan(point.Snapshot, stringStart, stringEnd - stringStart + 1);
+                            return true;
+                        }
+
+                        insideString = false;
+                    }
+                    else
+                    {
+                        stringStart = index;
+                        if (index > 0 && (text[index - 1] == 'N' || text[index - 1] == 'n'))
+                        {
+                            stringStart--;
+                        }
+
+                        insideString = true;
+                    }
+                }
+            }
+
+            if (insideString && position >= stringStart)
+            {
+                span = new SnapshotSpan(point.Snapshot, stringStart, text.Length - stringStart);
+                return true;
+            }
+
+            span = default;
+            return false;
+        }
+    }
+}

--- a/AxialSqlTools/source.extension.vsixmanifest
+++ b/AxialSqlTools/source.extension.vsixmanifest
@@ -19,5 +19,6 @@
   </Prerequisites>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
   </Assets>
 </PackageManifest>


### PR DESCRIPTION
## Summary
- extend the editor command filter to implement IVsTextViewFilter for double-click selection
- detect single-quoted SQL strings and select them entirely, including an N prefix
- fall back to the default word selection when not inside a quoted string

## Testing
- not run (not supported in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929fbe89d40833386dea937e1610a7c)