### PR TITLE
Expand CROSS/OUTER/APPLY join new-line formatting option

### DIFF
--- a/AxialSqlTools/Commands/Dialogs/FormatOptionsDialog.xaml
+++ b/AxialSqlTools/Commands/Dialogs/FormatOptionsDialog.xaml
@@ -38,7 +38,7 @@
                 Checked="formatSetting_Checked"
                 Unchecked="formatSetting_Unchecked"/>
             <CheckBox x:Name="MoveCrossJoinToNewLine" Margin="5"
-                Content="Place CROSS JOIN on a new line"
+                Content="Place CROSS/OUTER JOIN/APPLY on a new line"
                 Checked="formatSetting_Checked"
                 Unchecked="formatSetting_Unchecked"/>
             <CheckBox x:Name="FormatCaseAsMultiline" Margin="5"

--- a/AxialSqlTools/Modules/TsqlFormatter.cs
+++ b/AxialSqlTools/Modules/TsqlFormatter.cs
@@ -415,38 +415,45 @@ namespace AxialSqlTools
                     }
                 }
 
-            //special case #3 - CROSS should be on the new line
+            //special case #3 - CROSS/OUTER JOIN/APPLY should be on the new line
             if (formatSettings.moveCrossJoinToNewLine)
+            {
                 foreach (UnqualifiedJoin CrossJoin in visitor.UnqualifiedJoins)
                 {
-                    int NextTokenNumber = CrossJoin.SecondTableReference.FirstTokenIndex;
+                    MoveJoinKeywordToNewLine(
+                        sqlFragment,
+                        CrossJoin.SecondTableReference.FirstTokenIndex,
+                        CrossJoin.StartColumn,
+                        TSqlTokenType.Cross,
+                        TSqlTokenType.Outer);
+                }
 
-                    while (true)
+                foreach (QualifiedJoin qualifiedJoin in visitor.QualifiedJoins)
+                {
+                    TSqlTokenType? joinKeyword = null;
+                    switch (qualifiedJoin.QualifiedJoinType)
                     {
-
-                        TSqlParserToken NextToken = sqlFragment.ScriptTokenStream[NextTokenNumber];
-
-                        if (NextToken.TokenType == TSqlTokenType.Cross)
-                        { // replace previos white-space with the new line and a number of spaces for offset
-
-                            TSqlParserToken PreviousToken = sqlFragment.ScriptTokenStream[NextTokenNumber - 1];
-                            if (PreviousToken.TokenType == TSqlTokenType.WhiteSpace)
-                            {
-                                PreviousToken.Text = "\r\n" + new string(' ', CrossJoin.StartColumn - 1);
-                                break;
-                            }
-
-                        }
-
-                        NextTokenNumber -= 1;
-
-                        //just in case
-                        if (NextTokenNumber < 0)
+                        case QualifiedJoinType.LeftOuter:
+                            joinKeyword = TSqlTokenType.Left;
                             break;
-
+                        case QualifiedJoinType.RightOuter:
+                            joinKeyword = TSqlTokenType.Right;
+                            break;
+                        case QualifiedJoinType.FullOuter:
+                            joinKeyword = TSqlTokenType.Full;
+                            break;
                     }
 
+                    if (joinKeyword.HasValue)
+                    {
+                        MoveJoinKeywordToNewLine(
+                            sqlFragment,
+                            qualifiedJoin.SecondTableReference.FirstTokenIndex,
+                            qualifiedJoin.StartColumn,
+                            joinKeyword.Value);
+                    }
                 }
+            }
 
             //special case #4 - CASE <new line + tab> WHEN <new line + tab + tab> THEN <new line + tab> ELSE <new line> END
             if (formatSettings.formatCaseAsMultiline)
@@ -904,6 +911,35 @@ namespace AxialSqlTools
                     lines[i] = lines[i].Substring(indentString.Length);
             }
             return string.Join("\r\n", lines);
+        }
+
+        private static void MoveJoinKeywordToNewLine(
+            TSqlFragment sqlFragment,
+            int startTokenIndex,
+            int startColumn,
+            params TSqlTokenType[] tokenTypes)
+        {
+            var tokenSet = new HashSet<TSqlTokenType>(tokenTypes);
+            int nextTokenNumber = startTokenIndex;
+
+            while (true)
+            {
+                TSqlParserToken nextToken = sqlFragment.ScriptTokenStream[nextTokenNumber];
+
+                if (tokenSet.Contains(nextToken.TokenType))
+                {
+                    TSqlParserToken previousToken = sqlFragment.ScriptTokenStream[nextTokenNumber - 1];
+                    if (previousToken.TokenType == TSqlTokenType.WhiteSpace)
+                        previousToken.Text = "\r\n" + new string(' ', startColumn - 1);
+                    break;
+                }
+
+                nextTokenNumber -= 1;
+
+                //just in case
+                if (nextTokenNumber < 0)
+                    break;
+            }
         }
 
 

--- a/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
+++ b/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
@@ -332,7 +332,7 @@
                               Checked="formatSetting_Checked"
                               Unchecked="formatSetting_Unchecked"/>
                         <CheckBox x:Name="MoveCrossJoinToNewLine" Margin="5"
-                              Content="Place CROSS JOIN on a new line" 
+                              Content="Place CROSS/OUTER JOIN/APPLY on a new line" 
                               Checked="formatSetting_Checked"
                               Unchecked="formatSetting_Unchecked"/>
                         <CheckBox x:Name="FormatCaseAsMultiline" Margin="5"


### PR DESCRIPTION
### Motivation
- The existing formatting option only mentioned `CROSS JOIN` but the formatter should also handle `OUTER JOIN` and `APPLY` cases.
- Users expect consistent new-line placement for cross/outer/apply style joins across both qualified and unqualified join forms.
- The UI label needed to reflect the extended behavior so the setting is clear.

### Description
- Updated UI text in `Commands/Dialogs/FormatOptionsDialog.xaml` and `WindowSettings/SettingsWindowControl.xaml` to `Place CROSS/OUTER JOIN/APPLY on a new line` for the `MoveCrossJoinToNewLine` checkbox.
- Extended `TSqlFormatter` (in `Modules/TsqlFormatter.cs`) to move join keywords to a new line by searching for `TSqlTokenType.Cross` and `TSqlTokenType.Outer` for unqualified joins and by inspecting `QualifiedJoinType` for left/right/full outer joins.
- Added a shared helper method `MoveJoinKeywordToNewLine` to centralize token scanning and whitespace replacement logic.
- Covered both `UnqualifiedJoin` and `QualifiedJoin` visitors so `CROSS`, `OUTER`, `LEFT/RIGHT/FULL` outer joins (and indirectly `APPLY` where applicable) are handled consistently.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694945cd0848833398d7276121cc7e55)