### PR TITLE
Add IN Clause List copy commands (Selected / All)

### DIFF
--- a/AxialSqlTools/Commands/ResultGridCommands.cs
+++ b/AxialSqlTools/Commands/ResultGridCommands.cs
@@ -75,7 +75,7 @@ namespace AxialSqlTools
 
             var btnControlAllInClauseList = (CommandBarButton)copyAllPopup.Controls.Add(MsoControlType.msoControlButton, Type.Missing, Type.Missing, Type.Missing, true);
             btnControlAllInClauseList.Visible = true;
-            btnControlAllInClauseList.Caption = "IN Clause List";
+            btnControlAllInClauseList.Caption = "Values as IN (...)";
             btnControlAllInClauseList.Click += OnClick_CopyAllAsInClauseList;
 
             var copySelectedPopup = (CommandBarPopup)GridCommandBar.Controls.Add(MsoControlType.msoControlPopup, Type.Missing, Type.Missing, Type.Missing, true);
@@ -109,7 +109,7 @@ namespace AxialSqlTools
 
             var btnControlSelectedInClauseList = (CommandBarButton)copySelectedPopup.Controls.Add(MsoControlType.msoControlButton, Type.Missing, Type.Missing, Type.Missing, true);
             btnControlSelectedInClauseList.Visible = true;
-            btnControlSelectedInClauseList.Caption = "IN Clause List";
+            btnControlSelectedInClauseList.Caption = "Values as IN (...)";
             btnControlSelectedInClauseList.Click += OnClick_CopySelectedAsInClauseList;
 
             var btnControlCCN = (CommandBarButton)GridCommandBar.Controls.Add(MsoControlType.msoControlButton, Type.Missing, Type.Missing, Type.Missing, true);


### PR DESCRIPTION
### Motivation

- Provide a quick way to copy values from a single column as an SQL `IN` clause list (e.g. `(v1, v2, ...)`) from the results grid.
- Support both `Copy All As ...` and `Copy Selected As ...` menus and ensure only the current column is used.
- For `Selected` scope, collect values from the one currently focused column across all selected rows, and for `All` scope collect values from the one current column across all rows.

### Description

- Added new menu items labeled `IN Clause List` under both `Copy All As ...` and `Copy Selected As ...` in `ResultGridCommands.cs` and introduced `CopyFormat.InClauseList` to the enum.
- Implemented `CopyInClauseList` in `ResultGridCommands.cs` that uses `GetCellValueAsString` to collect and format values, copies `(<value1>, <value2>, ...)` to clipboard, and updates status text.
- Added helper methods to `ResultGridControlAdaptor.cs`: `GetCurrentColumnIndex`, `GetSelectedRowIndexesForColumn`, `TryGetCurrentColumnIndex`, and `TryGetColumnIndexFromCell` to reliably resolve the current column and selected rows for that column.
- Changes touch `ResultGridCommands.cs` and `ResultGridControlAdaptor.cs`, and use existing `SetClipboardText` and `GetCellValueAsString` behavior to preserve value formatting.

### Testing

- No automated tests were executed as part of this change.
- Existing automated test suites (if any) were not run against the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d5d63b4d48333ac524ed396016879)