### PR TITLE
Sanitize strings before PostgreSQL binary import

### DIFF
--- a/AxialSqlTools/DataTransfer/DataTransferWindowControl.xaml.cs
+++ b/AxialSqlTools/DataTransfer/DataTransferWindowControl.xaml.cs
@@ -574,6 +574,16 @@
             }
         }
 
+        private static object SanitizePostgresValue(object value)
+        {
+            if (value is string text && text.IndexOf('\0') >= 0)
+            {
+                return text.Replace("\0", string.Empty);
+            }
+
+            return value;
+        }
+
         private async void ButtonToPsql_CopyData_Click(object sender, RoutedEventArgs e)
         {
             // Ensure a target table name is provided.
@@ -677,6 +687,10 @@
                                             {
                                                 bool isNull = await reader.IsDBNullAsync(i, cancellationToken);
                                                 var value = isNull ? DBNull.Value : reader.GetValue(i);
+                                                if (!isNull)
+                                                {
+                                                    value = SanitizePostgresValue(value);
+                                                }
                                                 // Write each column value asynchronously.
                                                 await importer.WriteAsync(value, cancellationToken);
                                             }


### PR DESCRIPTION
### Motivation
- Fix a failure during SQL Server -> PostgreSQL binary `COPY` caused by embedded NUL (`\0`) characters in string columns that produce invalid UTF-8/0x00 errors.  
- Ensure the existing data transfer flow remains unchanged for non-string and null values while avoiding the transfer error.

### Description
- Added a helper `SanitizePostgresValue` in `DataTransferWindowControl.xaml.cs` that strips NUL characters from string values.  
- Updated the row-write loop in `ButtonToPsql_CopyData_Click` to call `SanitizePostgresValue` for non-null column values before calling `importer.WriteAsync`.  
- The change only alters in-flight values being written to PostgreSQL and preserves existing behavior for `DBNull.Value` and non-string types.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956a28d7c288333bae0902c3b661e65)