### PR TITLE
Add Quick Search tool window for cross-database object text lookup

### DIFF
--- a/AxialSqlTools/AxialSqlTools.csproj
+++ b/AxialSqlTools/AxialSqlTools.csproj
@@ -136,6 +136,11 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="QuickSearch\QuickSearchWindow.cs" />
+    <Compile Include="QuickSearch\QuickSearchWindowCommand.cs" />
+    <Compile Include="QuickSearch\QuickSearchWindowControl.xaml.cs">
+      <DependentUpon>QuickSearchWindowControl.xaml</DependentUpon>
+    </Compile>
     <Compile Include="QueryHistory\QueryHistoryRecord.cs" />
     <Compile Include="QueryHistory\QueryHistoryViewModel.cs" />
     <Compile Include="QueryHistory\QueryHistoryWindow.cs" />
@@ -356,6 +361,10 @@
     <Page Include="HealthDashboards\HealthDashboard_ServersControl.xaml">
       <SubType>Designer</SubType>
       <Generator>XamlIntelliSenseFileGenerator</Generator>
+    </Page>
+    <Page Include="QuickSearch\QuickSearchWindowControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="QueryHistory\QueryHistoryWindowControl.xaml">
       <SubType>Designer</SubType>

--- a/AxialSqlTools/AxialSqlToolsPackage.cs
+++ b/AxialSqlTools/AxialSqlToolsPackage.cs
@@ -66,6 +66,7 @@ namespace AxialSqlTools
     [ProvideToolWindow(typeof(DatabaseScripterToolWindow))]
     [ProvideToolWindow(typeof(SchemaCompareWindow))]
     [ProvideToolWindow(typeof(DataImportWindow))]
+    [ProvideToolWindow(typeof(QuickSearchWindow))]
     public sealed class AxialSqlToolsPackage : AsyncPackage
     {
 
@@ -294,6 +295,7 @@ namespace AxialSqlTools
                 await QueryHistoryWindowCommand.InitializeAsync(this);
                 await DatabaseScripterToolWindowCommand.InitializeAsync(this);
                 await SchemaCompareWindowCommand.InitializeAsync(this);
+                await QuickSearchWindowCommand.InitializeAsync(this);
 
             }
             catch (Exception ex)

--- a/AxialSqlTools/AxialSqlToolsPackage.vsct
+++ b/AxialSqlTools/AxialSqlToolsPackage.vsct
@@ -196,6 +196,15 @@
         </Strings>
       </Button>-->
 
+      <Button guid="guidAxialSqlToolsPackageCmdSet" id="AxialQuickSearchCommand" priority="0x0001" type="Button">
+        <Parent guid="guidAxialSqlToolsPackageCmdSet" id="AxialToolsSubMenuGroup_Script" />
+        <Icon guid="guidQueryHistory" id="bmpQueryHistory" />
+        <CommandFlag>IconAndText</CommandFlag>
+        <Strings>
+          <ButtonText>Quick Search</ButtonText>
+        </Strings>
+      </Button>
+
       <Button guid="guidAxialSqlToolsPackageCmdSet" id="AxialQueryHistoryCommand" priority="0x0000" type="Button">
         <Parent guid="guidAxialSqlToolsPackageCmdSet" id="AxialToolsSubMenuGroup_Script" />
         <Icon guid="guidQueryHistory" id="bmpQueryHistory" />
@@ -430,6 +439,8 @@
       <IDSymbol name="AxialCompareSchemasCommand" value="4149" />
 
       <IDSymbol name="AxialDataImportCommand" value="4150" />
+
+      <IDSymbol name="AxialQuickSearchCommand" value="4151" />
 
     </GuidSymbol>
 

--- a/AxialSqlTools/QuickSearch/QuickSearchWindow.cs
+++ b/AxialSqlTools/QuickSearch/QuickSearchWindow.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.VisualStudio.Shell;
+using System.Runtime.InteropServices;
+
+namespace AxialSqlTools
+{
+    [Guid("3f0450e0-5ef4-4d6b-bf0f-cfdd95d7c003")]
+    public class QuickSearchWindow : ToolWindowPane
+    {
+        public QuickSearchWindow() : base(null)
+        {
+            this.Caption = "Quick Search";
+            this.Content = new QuickSearchWindowControl();
+        }
+    }
+}

--- a/AxialSqlTools/QuickSearch/QuickSearchWindowCommand.cs
+++ b/AxialSqlTools/QuickSearch/QuickSearchWindowCommand.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.ComponentModel.Design;
+using System.Threading.Tasks;
+using Task = System.Threading.Tasks.Task;
+
+namespace AxialSqlTools
+{
+    internal sealed class QuickSearchWindowCommand
+    {
+        public const int CommandId = 4151;
+        public static readonly Guid CommandSet = new Guid("45457e02-6dec-4a4d-ab22-c9ee126d23c5");
+
+        private readonly AsyncPackage package;
+
+        private QuickSearchWindowCommand(AsyncPackage package, OleMenuCommandService commandService)
+        {
+            this.package = package ?? throw new ArgumentNullException(nameof(package));
+            commandService = commandService ?? throw new ArgumentNullException(nameof(commandService));
+
+            var menuCommandID = new CommandID(CommandSet, CommandId);
+            var menuItem = new MenuCommand(this.Execute, menuCommandID);
+            commandService.AddCommand(menuItem);
+        }
+
+        public static QuickSearchWindowCommand Instance { get; private set; }
+
+        public static async Task InitializeAsync(AsyncPackage package)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(package.DisposalToken);
+            OleMenuCommandService commandService = await package.GetServiceAsync(typeof(IMenuCommandService)) as OleMenuCommandService;
+            Instance = new QuickSearchWindowCommand(package, commandService);
+        }
+
+        private void Execute(object sender, EventArgs e)
+        {
+            this.package.JoinableTaskFactory.RunAsync(async delegate
+            {
+                ToolWindowPane window = await this.package.ShowToolWindowAsync(typeof(QuickSearchWindow), 0, true, this.package.DisposalToken);
+                if ((null == window) || (null == window.Frame))
+                {
+                    throw new NotSupportedException("Cannot create tool window");
+                }
+            });
+        }
+    }
+}

--- a/AxialSqlTools/QuickSearch/QuickSearchWindowControl.xaml
+++ b/AxialSqlTools/QuickSearch/QuickSearchWindowControl.xaml
@@ -1,0 +1,67 @@
+﻿<UserControl x:Class="AxialSqlTools.QuickSearchWindowControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d"
+             Name="QuickSearchControl">
+    <Grid Margin="5">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,8">
+            <Button Height="30"
+                    Width="280"
+                    Content="select conection from obkject explorer"
+                    FontWeight="Bold"
+                    Click="Button_SelectConnection_Click" />
+            <Label x:Name="Label_ConnectionDescription" Margin="8,0,0,0" VerticalAlignment="Center" Content="No connection selected"/>
+        </StackPanel>
+
+        <Grid Grid.Row="1" Margin="0,0,0,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="2*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <Label Grid.Column="0" Content="Search for:" VerticalAlignment="Center"/>
+            <TextBox Grid.Column="1" x:Name="TextBox_SearchText" Margin="6,0,12,0" Height="24" VerticalContentAlignment="Center"/>
+            <CheckBox Grid.Column="2" x:Name="CheckBox_AllDatabases" Content="All user databases on selected server" VerticalAlignment="Center" Margin="0,0,12,0" IsChecked="True"/>
+            <StackPanel Grid.Column="3" Orientation="Horizontal" VerticalAlignment="Center">
+                <CheckBox x:Name="CheckBox_WholeWord" Content="Match whole words only" Margin="0,0,12,0"/>
+                <CheckBox x:Name="CheckBox_UseWildcards" Content="Use wildcards" />
+            </StackPanel>
+            <Button Grid.Column="4" x:Name="Button_Search" Content="Search" Width="90" Height="28" Click="Button_Search_Click"/>
+        </Grid>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,0,0,8">
+            <Label Content="Object types:" VerticalAlignment="Center"/>
+            <CheckBox x:Name="CheckBox_StoredProcedures" Content="Stored Procedures" IsChecked="True" Margin="8,0,0,0"/>
+            <CheckBox x:Name="CheckBox_Views" Content="Views" IsChecked="True" Margin="8,0,0,0"/>
+            <CheckBox x:Name="CheckBox_Functions" Content="Functions" IsChecked="True" Margin="8,0,0,0"/>
+            <CheckBox x:Name="CheckBox_Tables" Content="Tables" IsChecked="True" Margin="8,0,0,0"/>
+            <TextBlock x:Name="TextBlock_ResultCount" Margin="20,0,0,0" VerticalAlignment="Center" FontWeight="Bold"/>
+        </StackPanel>
+
+        <DataGrid Grid.Row="3"
+                  x:Name="DataGrid_SearchResults"
+                  AutoGenerateColumns="False"
+                  IsReadOnly="True"
+                  SelectionMode="Single">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Database" Binding="{Binding DatabaseName}" Width="130"/>
+                <DataGridTextColumn Header="Type" Binding="{Binding ObjectType}" Width="140"/>
+                <DataGridTextColumn Header="Schema" Binding="{Binding SchemaName}" Width="120"/>
+                <DataGridTextColumn Header="Object" Binding="{Binding ObjectName}" Width="200"/>
+                <DataGridTextColumn Header="Location" Binding="{Binding MatchLocation}" Width="120"/>
+                <DataGridTextColumn Header="Match Preview" Binding="{Binding MatchPreview}" Width="*"/>
+            </DataGrid.Columns>
+        </DataGrid>
+    </Grid>
+</UserControl>

--- a/AxialSqlTools/QuickSearch/QuickSearchWindowControl.xaml.cs
+++ b/AxialSqlTools/QuickSearch/QuickSearchWindowControl.xaml.cs
@@ -1,0 +1,326 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace AxialSqlTools
+{
+    public partial class QuickSearchWindowControl : UserControl
+    {
+        private string selectedConnectionString;
+        private string selectedDatabase;
+        private string selectedServer;
+
+        public QuickSearchWindowControl()
+        {
+            InitializeComponent();
+        }
+
+        private void Button_SelectConnection_Click(object sender, RoutedEventArgs e)
+        {
+            var ci = ScriptFactoryAccess.GetCurrentConnectionInfoFromObjectExplorer();
+            if (ci == null)
+            {
+                MessageBox.Show("Please select a server or database node in Object Explorer first.", "Quick Search");
+                return;
+            }
+
+            selectedConnectionString = ci.FullConnectionString;
+            selectedDatabase = ci.Database;
+            selectedServer = ci.ServerName;
+            Label_ConnectionDescription.Content = $"Server: [{selectedServer}] / Database: [{selectedDatabase}]";
+        }
+
+        private async void Button_Search_Click(object sender, RoutedEventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(selectedConnectionString))
+            {
+                MessageBox.Show("Select a connection from Object Explorer first.", "Quick Search");
+                return;
+            }
+
+            string searchText = TextBox_SearchText.Text?.Trim();
+            if (string.IsNullOrEmpty(searchText))
+            {
+                MessageBox.Show("Enter text to search.", "Quick Search");
+                return;
+            }
+
+            if (!AnyTypeSelected())
+            {
+                MessageBox.Show("Select at least one object type.", "Quick Search");
+                return;
+            }
+
+            try
+            {
+                Button_Search.IsEnabled = false;
+                TextBlock_ResultCount.Text = "Searching...";
+
+                bool allDatabases = CheckBox_AllDatabases.IsChecked == true;
+                bool wholeWord = CheckBox_WholeWord.IsChecked == true;
+                bool useWildcards = CheckBox_UseWildcards.IsChecked == true;
+                bool includeProcs = CheckBox_StoredProcedures.IsChecked == true;
+                bool includeViews = CheckBox_Views.IsChecked == true;
+                bool includeFunctions = CheckBox_Functions.IsChecked == true;
+                bool includeTables = CheckBox_Tables.IsChecked == true;
+
+                DataTable results = await Task.Run(() => ExecuteSearch(searchText, allDatabases, wholeWord, useWildcards, includeProcs, includeViews, includeFunctions, includeTables));
+                DataGrid_SearchResults.ItemsSource = results.DefaultView;
+                TextBlock_ResultCount.Text = $"{results.Rows.Count} result(s)";
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Search failed: {ex.Message}", "Quick Search");
+                TextBlock_ResultCount.Text = "Search failed";
+            }
+            finally
+            {
+                Button_Search.IsEnabled = true;
+            }
+        }
+
+        private DataTable ExecuteSearch(string searchText, bool allDatabases, bool wholeWord, bool useWildcards, bool includeProcs, bool includeViews, bool includeFunctions, bool includeTables)
+        {
+            List<string> databases = GetDatabasesToSearch(allDatabases);
+            DataTable allResults = BuildResultTable();
+
+            foreach (string dbName in databases)
+            {
+                DataTable rows = SearchDatabase(dbName, searchText, useWildcards, includeProcs, includeViews, includeFunctions, includeTables);
+                foreach (DataRow row in rows.Rows)
+                {
+                    string sourceText = row["SourceText"]?.ToString() ?? string.Empty;
+                    if (wholeWord && !Regex.IsMatch(sourceText, $@"\b{Regex.Escape(searchText)}\b", RegexOptions.IgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    string preview = BuildPreview(sourceText, searchText, useWildcards);
+                    allResults.Rows.Add(
+                        row["DatabaseName"],
+                        row["ObjectType"],
+                        row["SchemaName"],
+                        row["ObjectName"],
+                        row["MatchLocation"],
+                        preview);
+                }
+            }
+
+            return allResults;
+        }
+
+        private List<string> GetDatabasesToSearch(bool allDatabases)
+        {
+            var list = new List<string>();
+
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(selectedConnectionString)
+            {
+                InitialCatalog = "master"
+            };
+
+            using (var conn = new SqlConnection(builder.ConnectionString))
+            {
+                conn.Open();
+
+                if (allDatabases)
+                {
+                    string sql = @"
+SELECT [name]
+FROM sys.databases
+WHERE database_id > 4
+  AND [state] = 0
+  AND user_access = 0
+ORDER BY [name];";
+
+                    using (var cmd = new SqlCommand(sql, conn))
+                    using (var reader = cmd.ExecuteReader())
+                    {
+                        while (reader.Read())
+                        {
+                            list.Add(reader.GetString(0));
+                        }
+                    }
+                }
+                else
+                {
+                    list.Add(selectedDatabase);
+                }
+            }
+
+            return list;
+        }
+
+        private DataTable SearchDatabase(string databaseName, string searchText, bool useWildcards, bool includeProcs, bool includeViews, bool includeFunctions, bool includeTables)
+        {
+            var result = new DataTable();
+
+            string sql = $@"
+USE [{databaseName}];
+
+SELECT
+    DB_NAME() AS DatabaseName,
+    CASE
+        WHEN o.[type] = 'P' THEN 'Stored Procedure'
+        WHEN o.[type] = 'V' THEN 'View'
+        ELSE 'Function'
+    END AS ObjectType,
+    s.[name] AS SchemaName,
+    o.[name] AS ObjectName,
+    'Definition' AS MatchLocation,
+    m.[definition] AS SourceText
+FROM sys.objects o
+INNER JOIN sys.schemas s ON s.schema_id = o.schema_id
+INNER JOIN sys.sql_modules m ON m.object_id = o.object_id
+WHERE (
+        (@includeProcs = 1 AND o.[type] = 'P') OR
+        (@includeViews = 1 AND o.[type] = 'V') OR
+        (@includeFunctions = 1 AND o.[type] IN ('FN', 'IF', 'TF'))
+      )
+  AND m.[definition] LIKE @pattern ESCAPE '\\'
+
+UNION ALL
+
+SELECT
+    DB_NAME() AS DatabaseName,
+    'Table' AS ObjectType,
+    s.[name] AS SchemaName,
+    t.[name] AS ObjectName,
+    'Table Name' AS MatchLocation,
+    t.[name] AS SourceText
+FROM sys.tables t
+INNER JOIN sys.schemas s ON s.schema_id = t.schema_id
+WHERE @includeTables = 1
+  AND t.[name] LIKE @pattern ESCAPE '\\'
+
+UNION ALL
+
+SELECT
+    DB_NAME() AS DatabaseName,
+    'Table' AS ObjectType,
+    s.[name] AS SchemaName,
+    t.[name] AS ObjectName,
+    'Column' AS MatchLocation,
+    c.[name] AS SourceText
+FROM sys.tables t
+INNER JOIN sys.schemas s ON s.schema_id = t.schema_id
+INNER JOIN sys.columns c ON c.object_id = t.object_id
+WHERE @includeTables = 1
+  AND c.[name] LIKE @pattern ESCAPE '\\'
+
+UNION ALL
+
+SELECT
+    DB_NAME() AS DatabaseName,
+    CASE
+        WHEN o.[type] = 'P' THEN 'Stored Procedure'
+        WHEN o.[type] = 'V' THEN 'View'
+        ELSE 'Function'
+    END AS ObjectType,
+    s.[name] AS SchemaName,
+    o.[name] AS ObjectName,
+    'Parameter' AS MatchLocation,
+    p.[name] AS SourceText
+FROM sys.parameters p
+INNER JOIN sys.objects o ON o.object_id = p.object_id
+INNER JOIN sys.schemas s ON s.schema_id = o.schema_id
+WHERE p.parameter_id > 0
+  AND (
+        (@includeProcs = 1 AND o.[type] = 'P') OR
+        (@includeViews = 1 AND o.[type] = 'V') OR
+        (@includeFunctions = 1 AND o.[type] IN ('FN', 'IF', 'TF'))
+      )
+  AND p.[name] LIKE @pattern ESCAPE '\\';";
+
+            string pattern = BuildPattern(searchText, useWildcards);
+
+            using (var conn = new SqlConnection(selectedConnectionString))
+            using (var cmd = new SqlCommand(sql, conn))
+            using (var adapter = new SqlDataAdapter(cmd))
+            {
+                cmd.CommandTimeout = 120;
+                cmd.Parameters.AddWithValue("@pattern", pattern);
+                cmd.Parameters.AddWithValue("@includeProcs", includeProcs ? 1 : 0);
+                cmd.Parameters.AddWithValue("@includeViews", includeViews ? 1 : 0);
+                cmd.Parameters.AddWithValue("@includeFunctions", includeFunctions ? 1 : 0);
+                cmd.Parameters.AddWithValue("@includeTables", includeTables ? 1 : 0);
+
+                conn.Open();
+                adapter.Fill(result);
+            }
+
+            return result;
+        }
+
+        private static string BuildPattern(string text, bool useWildcards)
+        {
+            if (useWildcards)
+            {
+                return text;
+            }
+
+            string escaped = text
+                .Replace("\\", "\\\\")
+                .Replace("%", "\\%")
+                .Replace("_", "\\_")
+                .Replace("[", "\\[");
+
+            return $"%{escaped}%";
+        }
+
+        private static string BuildPreview(string sourceText, string searchText, bool useWildcards)
+        {
+            if (string.IsNullOrEmpty(sourceText))
+            {
+                return string.Empty;
+            }
+
+            if (!useWildcards)
+            {
+                int index = sourceText.IndexOf(searchText, StringComparison.OrdinalIgnoreCase);
+                if (index >= 0)
+                {
+                    int start = Math.Max(0, index - 40);
+                    int length = Math.Min(sourceText.Length - start, searchText.Length + 80);
+                    string snippet = sourceText.Substring(start, length).Replace(Environment.NewLine, " ");
+                    int snippetIndex = snippet.IndexOf(searchText, StringComparison.OrdinalIgnoreCase);
+                    if (snippetIndex >= 0)
+                    {
+                        return snippet.Substring(0, snippetIndex) + "[" + snippet.Substring(snippetIndex, searchText.Length) + "]" + snippet.Substring(snippetIndex + searchText.Length);
+                    }
+
+                    return snippet;
+                }
+            }
+
+            return sourceText.Length > 120
+                ? sourceText.Substring(0, 120).Replace(Environment.NewLine, " ") + "..."
+                : sourceText.Replace(Environment.NewLine, " ");
+        }
+
+        private bool AnyTypeSelected()
+        {
+            return CheckBox_StoredProcedures.IsChecked == true
+                || CheckBox_Views.IsChecked == true
+                || CheckBox_Functions.IsChecked == true
+                || CheckBox_Tables.IsChecked == true;
+        }
+
+        private static DataTable BuildResultTable()
+        {
+            var table = new DataTable();
+            table.Columns.Add("DatabaseName", typeof(string));
+            table.Columns.Add("ObjectType", typeof(string));
+            table.Columns.Add("SchemaName", typeof(string));
+            table.Columns.Add("ObjectName", typeof(string));
+            table.Columns.Add("MatchLocation", typeof(string));
+            table.Columns.Add("MatchPreview", typeof(string));
+            return table;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, native Quick Search UI inside the extension so users can search for fragments (columns, parameters, strings, object definitions) across a server or selected databases without external tools or custom scripts.
- Allow capturing the active Object Explorer connection so searches target the same server/database context users are already working in.

### Description
- Added a new tool window and command: `QuickSearchWindow`, `QuickSearchWindowCommand`, and `QuickSearchWindowControl` (XAML + code-behind) that expose the feature in the extension UI and menu (command id `4151`).
- Implemented UI with a top button labeled `select conection from obkject explorer` to capture the Object Explorer connection, a search input, scope toggle for all user DBs vs selected DB, object-type filters (Stored Procedures, Views, Functions, Tables), options for "Match whole words only" and "Use wildcards", and a results grid with database, type, schema, object, match location and preview.
- Implemented search logic that queries each target database for object definitions (`sys.sql_modules`), table names/columns, and parameters using parameterized queries and builds preview snippets with highlighted matches.
- Registered the tool window in the package (`ProvideToolWindow` + `InitializeAsync` call), added a VSCT menu entry for the new command, and updated the project file to include the new source and XAML files.

### Testing
- Attempted `dotnet build AxialSqlTools/AxialSqlTools.sln -c Debug`, which failed in this environment because `dotnet` is not installed (build not validated here).
- Attempted `msbuild AxialSqlTools/AxialSqlTools.sln`, which also failed due to `msbuild` not being available in the environment (build not validated here).
- Performed automated repository checks (`rg`/searches) to confirm the new symbols, files and VSCT entries were added (searches succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e342b0b8083339aeb26b5641bd7ed)