### PR TITLE
Use Visual Studio theme brushes across XAML tool windows

### DIFF
--- a/AxialSqlTools/DataImport/DataImportWindowControl.xaml
+++ b/AxialSqlTools/DataImport/DataImportWindowControl.xaml
@@ -3,9 +3,12 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
              mc:Ignorable="d"
              d:DesignWidth="600"
-             d:DesignHeight="420">
+             d:DesignHeight="420"
+             Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+             Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}">
     <Grid Margin="12">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -18,11 +21,11 @@
             <TextBlock Text="Data Import" FontSize="20" FontWeight="SemiBold" />
             <TextBlock Margin="0,6,0,0"
                        TextWrapping="Wrap"
-                       Foreground="Gray"
+                       Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
                        Text="Use this window to import Excel spreadsheets into the database currently selected in Object Explorer." />
         </StackPanel>
 
-        <Border Grid.Row="1" Margin="0,16,0,0" Padding="12" BorderBrush="#FFD9D9D9" BorderThickness="1" CornerRadius="6">
+        <Border Grid.Row="1" Margin="0,16,0,0" Padding="12" BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.PanelBorderKey}}" BorderThickness="1" CornerRadius="6">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
@@ -66,7 +69,7 @@
             </Grid>
         </Border>
 
-        <Border Grid.Row="2" Margin="0,16,0,0" Padding="12" BorderBrush="#FFE8E8E8" BorderThickness="1" CornerRadius="6">
+        <Border Grid.Row="2" Margin="0,16,0,0" Padding="12" BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.PanelBorderKey}}" BorderThickness="1" CornerRadius="6">
             <StackPanel>
                 <TextBlock Text="Process checklist" FontWeight="SemiBold" />
                 <ItemsControl Margin="0,8,0,0">
@@ -81,7 +84,7 @@
         </Border>
 
         <DockPanel Grid.Row="3" Margin="0,16,0,0">
-            <TextBlock x:Name="TextBlock_Status" VerticalAlignment="Center" Foreground="Gray" Text="Choose an Excel file to get started." />
+            <TextBlock x:Name="TextBlock_Status" VerticalAlignment="Center" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}" Text="Choose an Excel file to get started." />
             <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
                 <Button x:Name="Button_Clear" Content="Reset" Margin="0,0,8,0" Padding="16,4" Click="ButtonClear_OnClick" />
                 <Button x:Name="Button_Import" Content="Import" Padding="24,6" IsEnabled="False" Click="ButtonImport_OnClick" />

--- a/AxialSqlTools/DataTransfer/DataTransferWindowControl.xaml
+++ b/AxialSqlTools/DataTransfer/DataTransferWindowControl.xaml
@@ -5,11 +5,13 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
              mc:Ignorable="d" FontSize="14"
+             Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+             Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
              Name="MyToolWindow">
     <Grid>
         <StackPanel Orientation="Vertical" >
 
-            <StackPanel Orientation="Horizontal" Background="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}" >
+            <StackPanel Orientation="Horizontal" Background="{DynamicResource {x:Static vsshell:VsBrushes.CommandBarGradientBeginKey}}" >
                 <TextBlock Margin="5" HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold" FontSize="18">Data Transfer</TextBlock>
             </StackPanel>
 

--- a/AxialSqlTools/DataTransfer/SavedConnectionManagerWindow.xaml
+++ b/AxialSqlTools/DataTransfer/SavedConnectionManagerWindow.xaml
@@ -1,10 +1,16 @@
-<Window x:Class="AxialSqlTools.SavedConnectionManagerWindow"
+﻿<Window x:Class="AxialSqlTools.SavedConnectionManagerWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+        mc:Ignorable="d"
         Title="Saved Connections"
         Height="400"
         Width="760"
-        WindowStartupLocation="CenterOwner">
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+        Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}">
     <Grid Margin="10">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="2*" />
@@ -61,7 +67,7 @@
             <TextBlock Text="Saved to: %LocalAppData%\AxialSQL\data-transfer-connections.json"
                    Margin="0,4,0,0"
                    FontStyle="Italic"
-                   Foreground="Gray"
+                   Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}" Opacity="0.8"
                    TextWrapping="Wrap"/>
             </StackPanel>
         </StackPanel>

--- a/AxialSqlTools/GridToEmail/ToolWindowGridToEmailControl.xaml
+++ b/AxialSqlTools/GridToEmail/ToolWindowGridToEmailControl.xaml
@@ -5,11 +5,13 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
              mc:Ignorable="d" 
+             Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+             Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
              Name="MyToolWindow"
              FontSize="14">
     <Grid >
         <StackPanel Orientation="Vertical" >
-            <StackPanel Orientation="Horizontal" Background="#FFB4B4B4">
+            <StackPanel Orientation="Horizontal" Background="{DynamicResource {x:Static vsshell:VsBrushes.CommandBarGradientBeginKey}}">
                 <TextBlock Margin="5" HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold" FontSize="18">Export the grid to a file and send it via email</TextBlock>
             </StackPanel>
             <StackPanel Orientation="Vertical">

--- a/AxialSqlTools/HealthDashboards/HealthDashboard_ServerControl.xaml
+++ b/AxialSqlTools/HealthDashboards/HealthDashboard_ServerControl.xaml
@@ -7,7 +7,9 @@
              xmlns:oxy="http://oxyplot.org/wpf"
              mc:Ignorable="d"
              d:DesignHeight="500" d:DesignWidth="1000"
-             x:Name="MyToolWindow">
+             x:Name="MyToolWindow"
+             Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+             Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}">
 
     <Grid>
         <!-- Overall layout: header row (Auto) + main content row (*) -->
@@ -17,7 +19,7 @@
         </Grid.RowDefinitions>
 
         <!-- Header -->
-        <DockPanel Grid.Row="0" Background="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}" Margin="0,0,0,5">
+        <DockPanel Grid.Row="0" Background="{DynamicResource {x:Static vsshell:VsBrushes.CommandBarGradientBeginKey}}" Margin="0,0,0,5">
             <TextBlock DockPanel.Dock="Left" Margin="5" VerticalAlignment="Center" 
                        FontWeight="Bold" FontSize="18">
                 Server Health Dashboard

--- a/AxialSqlTools/QuickSearch/QuickSearchWindowControl.xaml
+++ b/AxialSqlTools/QuickSearch/QuickSearchWindowControl.xaml
@@ -3,8 +3,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:avalonedit="http://icsharpcode.net/sharpdevelop/avalonedit"
              mc:Ignorable="d"
+             Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+             Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
              Name="QuickSearchControl">
     <Grid>
 
@@ -13,7 +16,7 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <StackPanel Grid.Row="0" Orientation="Horizontal" Background="#FFB4B4B4">
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Background="{DynamicResource {x:Static vsshell:VsBrushes.CommandBarGradientBeginKey}}">
             <TextBlock Margin="5" HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold" 
                        FontSize="18">Search for Object Definitions Across Multiple Databases</TextBlock>
         </StackPanel>

--- a/AxialSqlTools/SchemaCompare/SchemaCompareWindowControl.xaml
+++ b/AxialSqlTools/SchemaCompare/SchemaCompareWindowControl.xaml
@@ -1,9 +1,12 @@
-<UserControl x:Class="AxialSqlTools.SchemaCompareWindowControl"
+﻿<UserControl x:Class="AxialSqlTools.SchemaCompareWindowControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d" MinWidth="900" MinHeight="600">
+             xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+             mc:Ignorable="d" MinWidth="900" MinHeight="600"
+             Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+             Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}">
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     </UserControl.Resources>
@@ -14,7 +17,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" BorderBrush="#FFDDDDDD" BorderThickness="0,0,0,1" Padding="8">
+        <Border Grid.Row="0" BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.PanelBorderKey}}" BorderThickness="0,0,0,1" Padding="8">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
@@ -95,13 +98,13 @@
                                             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding DiffType}" Value="Inserted">
-                                                    <Setter Property="Background" Value="#FFE1FFE1" />
+                                                    <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}" />
                                                 </DataTrigger>
                                                 <DataTrigger Binding="{Binding DiffType}" Value="Deleted">
-                                                    <Setter Property="Background" Value="#FFF7D6D6" />
+                                                    <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.InfoBrushKey}}" />
                                                 </DataTrigger>
                                                 <DataTrigger Binding="{Binding DiffType}" Value="Modified">
-                                                    <Setter Property="Background" Value="#FFE9F3FF" />
+                                                    <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
                                                 </DataTrigger>
                                             </Style.Triggers>
                                         </Style>
@@ -115,7 +118,7 @@
                                                     <ColumnDefinition Width="*" />
                                                 </Grid.ColumnDefinitions>
                                                 <TextBlock Text="{Binding Indicator}" HorizontalAlignment="Center" />
-                                                <TextBlock Grid.Column="1" Text="{Binding LineNumber}" Foreground="#FF888888" HorizontalAlignment="Right"
+                                                <TextBlock Grid.Column="1" Text="{Binding LineNumber}" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.GrayTextKey}}" HorizontalAlignment="Right"
                                                            Margin="0,0,8,0" />
                                                 <TextBlock Grid.Column="2" Text="{Binding Text}" TextWrapping="NoWrap"
                                                            FontFamily="Consolas" />
@@ -123,7 +126,7 @@
                                         </DataTemplate>
                                     </ListView.ItemTemplate>
                                 </ListView>
-                                <TextBlock Text="Select a difference to preview the source definition." Foreground="#FF666666"
+                                <TextBlock Text="Select a difference to preview the source definition." Foreground="{DynamicResource {x:Static vsshell:VsBrushes.GrayTextKey}}"
                                            FontStyle="Italic" HorizontalAlignment="Center" VerticalAlignment="Center">
                                     <TextBlock.Style>
                                         <Style TargetType="TextBlock">
@@ -162,13 +165,13 @@
                                             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding DiffType}" Value="Inserted">
-                                                    <Setter Property="Background" Value="#FFE1FFE1" />
+                                                    <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}" />
                                                 </DataTrigger>
                                                 <DataTrigger Binding="{Binding DiffType}" Value="Deleted">
-                                                    <Setter Property="Background" Value="#FFF7D6D6" />
+                                                    <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.InfoBrushKey}}" />
                                                 </DataTrigger>
                                                 <DataTrigger Binding="{Binding DiffType}" Value="Modified">
-                                                    <Setter Property="Background" Value="#FFE9F3FF" />
+                                                    <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
                                                 </DataTrigger>
                                             </Style.Triggers>
                                         </Style>
@@ -182,7 +185,7 @@
                                                     <ColumnDefinition Width="*" />
                                                 </Grid.ColumnDefinitions>
                                                 <TextBlock Text="{Binding Indicator}" HorizontalAlignment="Center" />
-                                                <TextBlock Grid.Column="1" Text="{Binding LineNumber}" Foreground="#FF888888" HorizontalAlignment="Right"
+                                                <TextBlock Grid.Column="1" Text="{Binding LineNumber}" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.GrayTextKey}}" HorizontalAlignment="Right"
                                                            Margin="0,0,8,0" />
                                                 <TextBlock Grid.Column="2" Text="{Binding Text}" TextWrapping="NoWrap"
                                                            FontFamily="Consolas" />
@@ -190,7 +193,7 @@
                                         </DataTemplate>
                                     </ListView.ItemTemplate>
                                 </ListView>
-                                <TextBlock Text="Select a difference to preview the target definition." Foreground="#FF666666"
+                                <TextBlock Text="Select a difference to preview the target definition." Foreground="{DynamicResource {x:Static vsshell:VsBrushes.GrayTextKey}}"
                                            FontStyle="Italic" HorizontalAlignment="Center" VerticalAlignment="Center">
                                     <TextBlock.Style>
                                         <Style TargetType="TextBlock">
@@ -225,7 +228,7 @@
             </TabItem>
         </TabControl>
 
-        <Border Grid.Row="2" BorderBrush="#FFDDDDDD" BorderThickness="1,1,1,0" Padding="8">
+        <Border Grid.Row="2" BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.PanelBorderKey}}" BorderThickness="1,1,1,0" Padding="8">
             <DockPanel>
                 <TextBlock Text="{Binding Status}" VerticalAlignment="Center" />
                 <ProgressBar Width="180" Height="16" Margin="12,0,0,0" IsIndeterminate="True"

--- a/AxialSqlTools/SqlServerBuilds/SqlServerBuildsWindowControl.xaml
+++ b/AxialSqlTools/SqlServerBuilds/SqlServerBuildsWindowControl.xaml
@@ -32,7 +32,7 @@
                 </Style>
             </TreeView.Resources>
 
-            <TreeViewItem Header="SQL Versions" IsExpanded="True" FontSize="16" FontWeight="Bold" Foreground="DarkBlue"/>
+            <TreeViewItem Header="SQL Versions" IsExpanded="True" FontSize="16" FontWeight="Bold" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
         </TreeView>
     </Grid>
 </UserControl>

--- a/AxialSqlTools/SyncToGitHub/DatabaseScripterToolWindowControl.xaml
+++ b/AxialSqlTools/SyncToGitHub/DatabaseScripterToolWindowControl.xaml
@@ -3,14 +3,17 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
              mc:Ignorable="d"
              d:DesignWidth="600"
-             Name="MyToolWindow">
+             Name="MyToolWindow"
+             Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+             Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}">
     <Grid Margin="0">
         <!-- Frame 1: Main Sync UI -->
         <Grid Name="MainFrame" Visibility="Visible">
             <StackPanel Orientation="Vertical" VerticalAlignment="Top" Margin="0">
-                <StackPanel Orientation="Horizontal" Background="#FFB4B4B4">
+                <StackPanel Orientation="Horizontal" Background="{DynamicResource {x:Static vsshell:VsBrushes.CommandBarGradientBeginKey}}">
                     <TextBlock Margin="5" HorizontalAlignment="Center" VerticalAlignment="Top"
                                FontWeight="Bold" FontSize="18">
                         Sync to GitHub
@@ -65,13 +68,13 @@
                                 <TextBlock Name="RepoSyncOptionsTextBlock"
                                    Text="Sync options will appear here"
                                    FontStyle="Italic"
-                                   Foreground="Gray"/>
+                                   Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}" Opacity="0.8"/>
                             </StackPanel>
                             <StackPanel Orientation="Vertical" Margin="0,5,0,0">
                                 <TextBlock Name="RepoSyncDbsTextBlock"
                                    Text="List of databases will appear here"
                                    FontStyle="Italic"
-                                   Foreground="Gray"/>
+                                   Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}" Opacity="0.8"/>
                             </StackPanel>
                         </StackPanel>
                     </GroupBox>
@@ -106,7 +109,7 @@
         </Grid>
 
         <!-- Frame 2: Profile Editor -->
-        <Grid Name="ProfileEditorFrame" Visibility="Collapsed" Background="#FAFAFA">
+        <Grid Name="ProfileEditorFrame" Visibility="Collapsed" Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}">
             <StackPanel Margin="10">
                 <TextBlock Text="Edit Sync Profile" FontWeight="Bold" FontSize="16"/>
                 <TextBox Name="ProfileNameTextBox" Margin="0,10,0,0" />
@@ -157,7 +160,7 @@
                     <Button Content="Save Profile" Click="SaveProfile_Click"/>
                     <Button Content="Cancel" Click="CancelProfileEdit_Click" Margin="10,0,0,0"/>
                     <Button Content="Delete Profile" Click="DeleteProfile_Click" Margin="10,0,0,0"
-                    Background="#FFD9534F" Foreground="White"/>
+                    Background="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
                 </StackPanel>
             </StackPanel>
         </Grid>

--- a/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
+++ b/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
@@ -3,13 +3,16 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
 	mc:Ignorable="d"
-	Name="MyToolWindow">
+	Name="MyToolWindow"
+	Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+	Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}">
     
     <DockPanel>
         <Border DockPanel.Dock="Top"
-				Background="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}"
-				Padding="12" BorderBrush="Black" BorderThickness="0,0,0,1">
+				Background="{DynamicResource {x:Static vsshell:VsBrushes.CommandBarGradientBeginKey}}"
+				Padding="12" BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.PanelBorderKey}}" BorderThickness="0,0,0,1">
             <TextBlock Text="Axial SQL Tools - Settings"
 					   FontWeight="Bold"
 					   FontSize="20"
@@ -17,7 +20,7 @@
         </Border>
 
         <TabControl Margin="5"
-					BorderBrush="LightGray"
+					BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.PanelBorderKey}}"
 					BorderThickness="1">
 
             <TabItem Header="Query Templates">


### PR DESCRIPTION
### Motivation
- Make all VS tool-window and dialog XAML forms adapt to Visual Studio color themes (light/dark/high-contrast) by removing hard-coded colors and using VS-provided dynamic brushes. 
- Replace inline hex/grayscale colors used for headers, borders, and helper/status text so the extension looks correct in VS2026 themes.

### Description
- Replaced hard-coded color values with Visual Studio dynamic brushes by adding `xmlns:vsshell` and setting root `Background`/`Foreground` to `{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}` and `WindowTextKey` across multiple XAML files. 
- Converted header and bar backgrounds to `CommandBarGradientBeginKey`, borders to `PanelBorderKey`, and secondary text to `VsBrushes.WindowTextKey`/`VsBrushes.GrayTextKey` for consistent theming. 
- Updated schema-compare diff row highlights to use system dynamic brushes (`SystemColors.ControlLightBrushKey`, `SystemColors.InfoBrushKey`, `SystemColors.ControlBrushKey`) instead of fixed hex colors. 
- Cleaned up a few duplicate `xmlns` entries and ensured the modified XAML files remain well-formed, then committed the changes with the message `Improve theme compatibility across VS tool window forms`.

### Testing
- Parsed each modified XAML file with Python `xml.etree.ElementTree.parse(...)` and all files reported as well-formed XML (succeeded). 
- Attempted to build the solution with `dotnet build AxialSqlTools/AxialSqlTools.sln` and `msbuild ...`, but both commands could not run in this environment because `dotnet`/`msbuild` are not installed (environment limitation). 
- Verified the changes via repository checks (`git commit`) and textual searches to confirm `vsshell:VsBrushes` usages were applied across the targeted XAML files (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a751ebdae483338a42789d29b89d0b)