### PR TITLE
Scaffold query-based tab coloring infrastructure

### DIFF
--- a/AxialSqlTools/AxialSqlTools.csproj
+++ b/AxialSqlTools/AxialSqlTools.csproj
@@ -62,6 +62,10 @@
     <UseWinFormsOutOfProcDesigner>True</UseWinFormsOutOfProcDesigner>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="TabColoring\TabColoringConfigLoader.cs" />
+    <Compile Include="TabColoring\TabColoringConfigModels.cs" />
+    <Compile Include="TabColoring\TabColoringRdtManager.cs" />
+    <Compile Include="TabColoring\TabColoringRuleEngine.cs" />
     <Compile Include="DataImport\DataImportWindow.cs" />
     <Compile Include="DataImport\DataImportWindowCommand.cs" />
     <Compile Include="DataImport\DataImportWindowControl.xaml.cs">
@@ -185,6 +189,7 @@
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <EmbeddedResource Include="QuickSearch\sql.xshd" />
+    <EmbeddedResource Include="TabColoring\DefaultTabColoringConfig.json" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/AxialSqlTools/AxialSqlToolsPackage.cs
+++ b/AxialSqlTools/AxialSqlToolsPackage.cs
@@ -27,6 +27,7 @@ using Microsoft.Data.SqlClient;
 using System.Data;
 using System.Linq;
 using AxialSqlTools.Properties;
+using AxialSqlTools.TabColoring;
 
 namespace AxialSqlTools
 {
@@ -240,6 +241,8 @@ namespace AxialSqlTools
 
         private int numberOfWindowsOpen = 0;
 
+        private TabColoringRdtManager _tabColoringRdtManager;
+
         public int GetNextToolWindowId()
         {
             numberOfWindowsOpen += 1;
@@ -270,6 +273,7 @@ namespace AxialSqlTools
             PackageInstance = this;
 
             InitializeLogging();
+            TabColoringConfigLoader.EnsureDefaultConfigExists();
 
             try
             {
@@ -296,6 +300,8 @@ namespace AxialSqlTools
                 await DatabaseScripterToolWindowCommand.InitializeAsync(this);
                 await SchemaCompareWindowCommand.InitializeAsync(this);
                 await QuickSearchWindowCommand.InitializeAsync(this);
+
+                _tabColoringRdtManager = await TabColoringRdtManager.CreateAndStartAsync(this, cancellationToken);
 
             }
             catch (Exception ex)

--- a/AxialSqlTools/TabColoring/DefaultTabColoringConfig.json
+++ b/AxialSqlTools/TabColoring/DefaultTabColoringConfig.json
@@ -1,0 +1,26 @@
+{
+  "description": "Tab coloring rules based on SQL queries executed against active connection. No regex matching is used.",
+  "settings": {
+    "enabled": false,
+    "queryTimeoutSeconds": 5,
+    "defaultColorIndex": null
+  },
+  "queryRules": [
+    {
+      "name": "Sysadmin sessions",
+      "query": "SELECT CASE WHEN IS_SRVROLEMEMBER('sysadmin') = 1 THEN 'SA' ELSE 'NON_SA' END;",
+      "expectedValue": "SA",
+      "colorIndex": 1,
+      "priority": 100,
+      "isEnabled": true
+    },
+    {
+      "name": "Non-sysadmin sessions",
+      "query": "SELECT CASE WHEN IS_SRVROLEMEMBER('sysadmin') = 1 THEN 'SA' ELSE 'NON_SA' END;",
+      "expectedValue": "NON_SA",
+      "colorIndex": 10,
+      "priority": 90,
+      "isEnabled": true
+    }
+  ]
+}

--- a/AxialSqlTools/TabColoring/TabColoringConfigLoader.cs
+++ b/AxialSqlTools/TabColoring/TabColoringConfigLoader.cs
@@ -1,0 +1,106 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Serialization.Json;
+using System.Text;
+
+namespace AxialSqlTools.TabColoring
+{
+    internal static class TabColoringConfigLoader
+    {
+        private const string DefaultConfigResourceName = "AxialSqlTools.TabColoring.DefaultTabColoringConfig.json";
+
+        public static string GetUserConfigPath()
+        {
+            string docs = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            return Path.Combine(docs, "AxialSqlTools", "TabColoringConfig.json");
+        }
+
+        public static void EnsureDefaultConfigExists()
+        {
+            try
+            {
+                string path = GetUserConfigPath();
+                string dir = Path.GetDirectoryName(path);
+                if (!Directory.Exists(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+
+                if (File.Exists(path))
+                {
+                    return;
+                }
+
+                string defaultJson = ReadDefaultConfigJsonOrNull();
+                if (string.IsNullOrWhiteSpace(defaultJson))
+                {
+                    defaultJson = "{\n  \"settings\": { \"enabled\": false },\n  \"queryRules\": []\n}\n";
+                }
+
+                File.WriteAllText(path, defaultJson, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            }
+            catch
+            {
+            }
+        }
+
+        public static TabColoringConfig LoadOrNull()
+        {
+            try
+            {
+                string path = GetUserConfigPath();
+                if (!File.Exists(path))
+                {
+                    return null;
+                }
+
+                string jsonText = File.ReadAllText(path, Encoding.UTF8);
+                if (string.IsNullOrWhiteSpace(jsonText))
+                {
+                    return null;
+                }
+
+                jsonText = jsonText.TrimStart('\uFEFF', '\u200B', '\u0000', ' ', '\t', '\r', '\n');
+                byte[] utf8Bytes = Encoding.UTF8.GetBytes(jsonText);
+                using (var stream = new MemoryStream(utf8Bytes))
+                {
+                    var serializer = new DataContractJsonSerializer(typeof(TabColoringConfig), new DataContractJsonSerializerSettings
+                    {
+                        UseSimpleDictionaryFormat = true
+                    });
+
+                    return serializer.ReadObject(stream) as TabColoringConfig;
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string ReadDefaultConfigJsonOrNull()
+        {
+            try
+            {
+                Assembly asm = typeof(TabColoringConfigLoader).Assembly;
+                using (Stream s = asm.GetManifestResourceStream(DefaultConfigResourceName))
+                {
+                    if (s == null)
+                    {
+                        return null;
+                    }
+
+                    using (var reader = new StreamReader(s, Encoding.UTF8, detectEncodingFromByteOrderMarks: true))
+                    {
+                        return reader.ReadToEnd();
+                    }
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/AxialSqlTools/TabColoring/TabColoringConfigModels.cs
+++ b/AxialSqlTools/TabColoring/TabColoringConfigModels.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace AxialSqlTools.TabColoring
+{
+    [DataContract]
+    internal sealed class TabColoringConfig
+    {
+        [DataMember(Name = "description", IsRequired = false, Order = 0)]
+        public string Description { get; set; }
+
+        [DataMember(Name = "settings", IsRequired = false, Order = 1)]
+        public TabColoringSettings Settings { get; set; } = new TabColoringSettings();
+
+        [DataMember(Name = "queryRules", IsRequired = false, Order = 2)]
+        public List<TabColoringQueryRule> QueryRules { get; set; } = new List<TabColoringQueryRule>();
+    }
+
+    [DataContract]
+    internal sealed class TabColoringSettings
+    {
+        [DataMember(Name = "enabled", IsRequired = false, Order = 0)]
+        public bool Enabled { get; set; } = false;
+
+        [DataMember(Name = "queryTimeoutSeconds", IsRequired = false, Order = 1)]
+        public int QueryTimeoutSeconds { get; set; } = 5;
+
+        [DataMember(Name = "defaultColorIndex", IsRequired = false, Order = 2)]
+        public int? DefaultColorIndex { get; set; }
+    }
+
+    [DataContract]
+    internal sealed class TabColoringQueryRule
+    {
+        [DataMember(Name = "name", IsRequired = false, Order = 0)]
+        public string Name { get; set; }
+
+        [DataMember(Name = "query", IsRequired = true, Order = 1)]
+        public string Query { get; set; }
+
+        [DataMember(Name = "expectedValue", IsRequired = false, Order = 2)]
+        public string ExpectedValue { get; set; }
+
+        [DataMember(Name = "colorIndex", IsRequired = true, Order = 3)]
+        public int ColorIndex { get; set; }
+
+        [DataMember(Name = "priority", IsRequired = false, Order = 4)]
+        public int Priority { get; set; } = 0;
+
+        [DataMember(Name = "isEnabled", IsRequired = false, Order = 5)]
+        public bool IsEnabled { get; set; } = true;
+    }
+}

--- a/AxialSqlTools/TabColoring/TabColoringRdtManager.cs
+++ b/AxialSqlTools/TabColoring/TabColoringRdtManager.cs
@@ -1,0 +1,69 @@
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AxialSqlTools.TabColoring
+{
+    internal sealed class TabColoringRdtManager : IVsRunningDocTableEvents3, IDisposable
+    {
+        private readonly IVsRunningDocumentTable _rdt;
+        private uint _rdtEventsCookie;
+
+        private TabColoringRdtManager(IVsRunningDocumentTable rdt)
+        {
+            _rdt = rdt ?? throw new ArgumentNullException(nameof(rdt));
+        }
+
+        public static async Task<TabColoringRdtManager> CreateAndStartAsync(AsyncPackage package, CancellationToken cancellationToken)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var rdt = await package.GetServiceAsync(typeof(SVsRunningDocumentTable)) as IVsRunningDocumentTable;
+            if (rdt == null)
+            {
+                return null;
+            }
+
+            var manager = new TabColoringRdtManager(rdt);
+            manager.Start();
+            return manager;
+        }
+
+        private void Start()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            _rdt.AdviseRunningDocTableEvents(this, out _rdtEventsCookie);
+        }
+
+        public void Dispose()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (_rdtEventsCookie != 0)
+            {
+                _rdt.UnadviseRunningDocTableEvents(_rdtEventsCookie);
+                _rdtEventsCookie = 0;
+            }
+        }
+
+        public int OnAfterAttributeChangeEx(uint docCookie, uint grfAttribs, IVsHierarchy pHierOld, uint itemidOld, string pszMkDocumentOld, IVsHierarchy pHierNew, uint itemidNew, string pszMkDocumentNew)
+        {
+            // Infrastructure hook only.
+            // Next implementation step: detect active SQL query window + active connection,
+            // execute query rules against that connection and map first match to SSMS color index.
+            _ = TabColoringConfigLoader.LoadOrNull();
+            return VSConstants.S_OK;
+        }
+
+        public int OnAfterAttributeChange(uint docCookie, uint grfAttribs) => VSConstants.S_OK;
+        public int OnAfterDocumentWindowHide(uint docCookie, IVsWindowFrame pFrame) => VSConstants.S_OK;
+        public int OnAfterFirstDocumentLock(uint docCookie, uint dwRDTLockType, uint dwReadLocksRemaining, uint dwEditLocksRemaining) => VSConstants.S_OK;
+        public int OnAfterSave(uint docCookie) => VSConstants.S_OK;
+        public int OnBeforeDocumentWindowShow(uint docCookie, int fFirstShow, IVsWindowFrame pFrame) => VSConstants.S_OK;
+        public int OnBeforeLastDocumentUnlock(uint docCookie, uint dwRDTLockType, uint dwReadLocksRemaining, uint dwEditLocksRemaining) => VSConstants.S_OK;
+        public int OnBeforeSave(uint docCookie) => VSConstants.S_OK;
+    }
+}

--- a/AxialSqlTools/TabColoring/TabColoringRuleEngine.cs
+++ b/AxialSqlTools/TabColoring/TabColoringRuleEngine.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AxialSqlTools.TabColoring
+{
+    internal static class TabColoringRuleEngine
+    {
+        public static IReadOnlyList<TabColoringQueryRule> GetEnabledRulesInPriorityOrder(TabColoringConfig config)
+        {
+            if (config?.QueryRules == null)
+            {
+                return Array.Empty<TabColoringQueryRule>();
+            }
+
+            return config.QueryRules
+                .Where(r => r != null && r.IsEnabled && !string.IsNullOrWhiteSpace(r.Query))
+                .OrderByDescending(r => r.Priority)
+                .ToList();
+        }
+
+        public static bool IsMatch(TabColoringQueryRule rule, object queryResult)
+        {
+            if (rule == null)
+            {
+                return false;
+            }
+
+            if (queryResult == null || queryResult == DBNull.Value)
+            {
+                return string.IsNullOrEmpty(rule.ExpectedValue);
+            }
+
+            if (string.IsNullOrEmpty(rule.ExpectedValue))
+            {
+                return true;
+            }
+
+            return string.Equals(Convert.ToString(queryResult), rule.ExpectedValue, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Add infrastructure to support tab coloring driven by SQL queries executed against the active connection (no regex matching). 
- Reuse the lifecycle/hooks approach from the SSMS-EnvTabs extension so future work can resolve active connection, run user-defined queries and map results to SSMS color indexes.

### Description
- Added a new `TabColoring` module containing strongly-typed config models (`TabColoringConfig`, `TabColoringSettings`, `TabColoringQueryRule`) to represent query-driven rules.
- Implemented `TabColoringConfigLoader` to seed a default user config under `Documents\AxialSqlTools\TabColoringConfig.json`, load the JSON config, and expose an embedded default template resource (`DefaultTabColoringConfig.json`).
- Implemented `TabColoringRuleEngine` helpers to enumerate enabled rules in priority order and perform scalar result matching (string/equality semantics; empty `expectedValue` means wildcard).
- Added `TabColoringRdtManager` scaffold that subscribes to `IVsRunningDocumentTable` events as the integration point where active SQL windows and connections will be detected and query rules executed.
- Wired the new infra into the extension: added files to the project (`.csproj`), embedded the default JSON resource, and updated package startup (`AxialSqlToolsPackage`) to `EnsureDefaultConfigExists()` and start `TabColoringRdtManager` during `InitializeAsync()`.
- Included a sample embedded default config with two example rules demonstrating the SA vs NON_SA query pattern and mapping results to color indexes.

### Testing
- Attempted a local build with `dotnet build AxialSqlTools/AxialSqlTools.sln` but it failed because the `dotnet` CLI is not available in this environment (`bash: command not found: dotnet`).
- Verified repository operations: `git status` and the commit succeeded (changes committed under message "Scaffold query-based tab coloring infrastructure").
- No automated unit tests were added or run as part of this scaffolding change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adf9210af4833391703d91de145203)