### PR TITLE
Add Query History status indicator in Settings form

### DIFF
--- a/AxialSqlTools/AxialSqlToolsPackage.cs
+++ b/AxialSqlTools/AxialSqlToolsPackage.cs
@@ -103,6 +103,7 @@ namespace AxialSqlTools
         }
 
         private const string QueryHistoryStorageModeTextFiles = "TextFiles";
+        private const string QueryHistoryStorageModeDisabled = "Disabled";
 
         private static ConcurrentQueue<QueryHistoryEntry> _queryHistoryQueue = new ConcurrentQueue<QueryHistoryEntry>();
         public static Logger _logger;
@@ -167,6 +168,11 @@ namespace AxialSqlTools
             try
             {
                 string storageMode = SettingsManager.GetQueryHistoryStorageMode();
+                if (string.Equals(storageMode, QueryHistoryStorageModeDisabled, StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+
                 if (string.Equals(storageMode, QueryHistoryStorageModeTextFiles, StringComparison.OrdinalIgnoreCase))
                 {
                     await PersistDataAsJsonLineAsync(data);

--- a/AxialSqlTools/QueryHistory/QueryHistoryViewModel.cs
+++ b/AxialSqlTools/QueryHistory/QueryHistoryViewModel.cs
@@ -16,6 +16,7 @@ namespace AxialSqlTools
     public class QueryHistoryViewModel : INotifyPropertyChanged
     {
         private const string QueryHistoryStorageModeTextFiles = "TextFiles";
+        private const string QueryHistoryStorageModeDisabled = "Disabled";
         private class QueryHistoryFileEntry
         {
             public DateTime StartTime { get; set; }
@@ -155,7 +156,11 @@ namespace AxialSqlTools
             try
             {
                 string storageMode = SettingsManager.GetQueryHistoryStorageMode();
-                if (string.Equals(storageMode, QueryHistoryStorageModeTextFiles, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(storageMode, QueryHistoryStorageModeDisabled, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Query history is disabled; keep the list empty.
+                }
+                else if (string.Equals(storageMode, QueryHistoryStorageModeTextFiles, StringComparison.OrdinalIgnoreCase))
                 {
                     LoadFromTextFiles();
                 }

--- a/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
+++ b/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
@@ -214,6 +214,18 @@
                 <Run Text="Wiki"/>
             </Hyperlink>
                     </TextBlock>
+                    <StackPanel Grid.Row="0" Grid.Column="1"
+                                Margin="10"
+                                Orientation="Horizontal"
+                                HorizontalAlignment="Right">
+                        <TextBlock Text="Status:"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,6,0"/>
+                        <TextBlock x:Name="QueryHistoryStatusIndicator"
+                                   VerticalAlignment="Center"
+                                   FontWeight="Bold"
+                                   Text="Disabled"/>
+                    </StackPanel>
 
                     <Label Grid.Row="1" Grid.Column="0"
                Content="Storage Type:"

--- a/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
+++ b/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
@@ -313,15 +313,7 @@
                         </Grid>
                     </GroupBox>
 
-                    <Button Content="Disable Query History"
-                Grid.Row="9" Grid.Column="1"
-                x:Name="button_DisableQueryHistory"
-                Click="Button_DisableQueryHistory_Click"
-                Width="150" HorizontalAlignment="Left"
-                Margin="5"
-                FontWeight="Bold"/>
-
-                    <Button Grid.Row="10" Grid.Column="0"
+                    <Button Grid.Row="9" Grid.Column="0"
                 x:Name="button_SaveQueryHistory"
                 Click="Button_SaveQueryHistory_Click"
                 Width="80"

--- a/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
+++ b/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
@@ -235,6 +235,7 @@
                  Margin="5"
                  VerticalContentAlignment="Center"
                  SelectionChanged="QueryHistoryStorageType_SelectionChanged">
+                        <ComboBoxItem Content="Disabled" Tag="Disabled"/>
                         <ComboBoxItem Content="Database table" Tag="Database"/>
                         <ComboBoxItem Content="Text files (JSONL)" Tag="TextFiles"/>
                     </ComboBox>

--- a/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
+++ b/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
@@ -214,19 +214,6 @@
                 <Run Text="Wiki"/>
             </Hyperlink>
                     </TextBlock>
-                    <StackPanel Grid.Row="0" Grid.Column="1"
-                                Margin="10"
-                                Orientation="Horizontal"
-                                HorizontalAlignment="Right">
-                        <TextBlock Text="Status:"
-                                   VerticalAlignment="Center"
-                                   Margin="0,0,6,0"/>
-                        <TextBlock x:Name="QueryHistoryStatusIndicator"
-                                   VerticalAlignment="Center"
-                                   FontWeight="Bold"
-                                   Text="Disabled"/>
-                    </StackPanel>
-
                     <Label Grid.Row="1" Grid.Column="0"
                Content="Storage Type:"
                Margin="5"/>

--- a/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml.cs
+++ b/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml.cs
@@ -24,6 +24,7 @@
     {
         private const string QueryHistoryStorageModeDatabase = "Database";
         private const string QueryHistoryStorageModeTextFiles = "TextFiles";
+        private const string QueryHistoryStorageModeDisabled = "Disabled";
 
         private string _queryHistoryConnectionString;
         private readonly ToolWindowThemeController _themeController;
@@ -206,8 +207,9 @@ as select 1;
 
         private bool IsQueryHistoryEnabled()
         {
+            bool isDisabledStorage = string.Equals(GetSelectedQueryHistoryStorageType(), QueryHistoryStorageModeDisabled, StringComparison.OrdinalIgnoreCase);
             bool isTextFilesStorage = string.Equals(GetSelectedQueryHistoryStorageType(), QueryHistoryStorageModeTextFiles, StringComparison.OrdinalIgnoreCase);
-            return isTextFilesStorage || !string.IsNullOrWhiteSpace(_queryHistoryConnectionString);
+            return !isDisabledStorage && (isTextFilesStorage || !string.IsNullOrWhiteSpace(_queryHistoryConnectionString));
         }
 
         private void UpdateQueryHistoryStatusIndicator()
@@ -542,14 +544,15 @@ as select 1;
 
         private void Button_DisableQueryHistory_Click(object sender, RoutedEventArgs e)
         {
-
             _queryHistoryConnectionString = "";
+            SelectQueryHistoryStorageType(QueryHistoryStorageModeDisabled);
+            SettingsManager.SaveQueryHistoryConnectionString(_queryHistoryConnectionString);
+            SettingsManager.SaveQueryHistoryStorageMode(QueryHistoryStorageModeDisabled);
 
             UpdateQueryHistoryConnectionDetails();
             UpdateQueryHistoryStorageControls();
-
             RefreshQueryHistoryCreateScript();
-
+            SavedMessage();
         }
 
         private string GetSelectedQueryHistoryStorageType()
@@ -580,6 +583,7 @@ as select 1;
 
         private void UpdateQueryHistoryStorageControls()
         {
+            bool isDisabledStorage = string.Equals(GetSelectedQueryHistoryStorageType(), QueryHistoryStorageModeDisabled, StringComparison.OrdinalIgnoreCase);
             bool isDatabaseStorage = string.Equals(GetSelectedQueryHistoryStorageType(), QueryHistoryStorageModeDatabase, StringComparison.OrdinalIgnoreCase);
             Label_QueryHistoryConnectionInfoTitle.Visibility = isDatabaseStorage ? Visibility.Visible : Visibility.Collapsed;
             Label_QueryHistoryConnectionInfo.Visibility = isDatabaseStorage ? Visibility.Visible : Visibility.Collapsed;
@@ -588,8 +592,8 @@ as select 1;
             QueryHistoryTableName.Visibility = isDatabaseStorage ? Visibility.Visible : Visibility.Collapsed;
             Label_QueryHistoryTargetTableHint.Visibility = isDatabaseStorage ? Visibility.Visible : Visibility.Collapsed;
             Group_QueryHistoryCreateScript.Visibility = isDatabaseStorage ? Visibility.Visible : Visibility.Collapsed;
-            QueryHistoryTextFilesPanel.Visibility = isDatabaseStorage ? Visibility.Collapsed : Visibility.Visible;
-            Label_QueryHistoryTextFilesInfo.Visibility = isDatabaseStorage ? Visibility.Collapsed : Visibility.Visible;
+            QueryHistoryTextFilesPanel.Visibility = (!isDatabaseStorage && !isDisabledStorage) ? Visibility.Visible : Visibility.Collapsed;
+            Label_QueryHistoryTextFilesInfo.Visibility = (!isDatabaseStorage && !isDisabledStorage) ? Visibility.Visible : Visibility.Collapsed;
             UpdateQueryHistoryStatusIndicator();
         }
 

--- a/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml.cs
+++ b/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml.cs
@@ -202,26 +202,6 @@ as select 1;
                 }
             }
 
-            UpdateQueryHistoryStatusIndicator();
-        }
-
-        private bool IsQueryHistoryEnabled()
-        {
-            bool isDisabledStorage = string.Equals(GetSelectedQueryHistoryStorageType(), QueryHistoryStorageModeDisabled, StringComparison.OrdinalIgnoreCase);
-            bool isTextFilesStorage = string.Equals(GetSelectedQueryHistoryStorageType(), QueryHistoryStorageModeTextFiles, StringComparison.OrdinalIgnoreCase);
-            return !isDisabledStorage && (isTextFilesStorage || !string.IsNullOrWhiteSpace(_queryHistoryConnectionString));
-        }
-
-        private void UpdateQueryHistoryStatusIndicator()
-        {
-            if (QueryHistoryStatusIndicator == null)
-            {
-                return;
-            }
-
-            bool isEnabled = IsQueryHistoryEnabled();
-            QueryHistoryStatusIndicator.Text = isEnabled ? "Enabled" : "Disabled";
-            QueryHistoryStatusIndicator.Foreground = GetThemedStatusBrush(isEnabled);
         }
 
         private void Button_SaveScriptFolder_Click(object sender, RoutedEventArgs e)
@@ -581,7 +561,6 @@ as select 1;
             Group_QueryHistoryCreateScript.Visibility = isDatabaseStorage ? Visibility.Visible : Visibility.Collapsed;
             QueryHistoryTextFilesPanel.Visibility = (!isDatabaseStorage && !isDisabledStorage) ? Visibility.Visible : Visibility.Collapsed;
             Label_QueryHistoryTextFilesInfo.Visibility = (!isDatabaseStorage && !isDisabledStorage) ? Visibility.Visible : Visibility.Collapsed;
-            UpdateQueryHistoryStatusIndicator();
         }
 
         private void QueryHistoryStorageType_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml.cs
+++ b/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml.cs
@@ -200,6 +200,26 @@ as select 1;
                     Label_QueryHistoryConnectionInfo.Text = ex.Message;
                 }
             }
+
+            UpdateQueryHistoryStatusIndicator();
+        }
+
+        private bool IsQueryHistoryEnabled()
+        {
+            bool isTextFilesStorage = string.Equals(GetSelectedQueryHistoryStorageType(), QueryHistoryStorageModeTextFiles, StringComparison.OrdinalIgnoreCase);
+            return isTextFilesStorage || !string.IsNullOrWhiteSpace(_queryHistoryConnectionString);
+        }
+
+        private void UpdateQueryHistoryStatusIndicator()
+        {
+            if (QueryHistoryStatusIndicator == null)
+            {
+                return;
+            }
+
+            bool isEnabled = IsQueryHistoryEnabled();
+            QueryHistoryStatusIndicator.Text = isEnabled ? "Enabled" : "Disabled";
+            QueryHistoryStatusIndicator.Foreground = GetThemedStatusBrush(isEnabled);
         }
 
         private void Button_SaveScriptFolder_Click(object sender, RoutedEventArgs e)
@@ -570,6 +590,7 @@ as select 1;
             Group_QueryHistoryCreateScript.Visibility = isDatabaseStorage ? Visibility.Visible : Visibility.Collapsed;
             QueryHistoryTextFilesPanel.Visibility = isDatabaseStorage ? Visibility.Collapsed : Visibility.Visible;
             Label_QueryHistoryTextFilesInfo.Visibility = isDatabaseStorage ? Visibility.Collapsed : Visibility.Visible;
+            UpdateQueryHistoryStatusIndicator();
         }
 
         private void QueryHistoryStorageType_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml.cs
+++ b/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml.cs
@@ -542,19 +542,6 @@ as select 1;
             }
         }
 
-        private void Button_DisableQueryHistory_Click(object sender, RoutedEventArgs e)
-        {
-            _queryHistoryConnectionString = "";
-            SelectQueryHistoryStorageType(QueryHistoryStorageModeDisabled);
-            SettingsManager.SaveQueryHistoryConnectionString(_queryHistoryConnectionString);
-            SettingsManager.SaveQueryHistoryStorageMode(QueryHistoryStorageModeDisabled);
-
-            UpdateQueryHistoryConnectionDetails();
-            UpdateQueryHistoryStorageControls();
-            RefreshQueryHistoryCreateScript();
-            SavedMessage();
-        }
-
         private string GetSelectedQueryHistoryStorageType()
         {
             if (QueryHistoryStorageType.SelectedItem is ComboBoxItem item)


### PR DESCRIPTION
### Motivation
- Provide an on-form visual indicator so the Query History settings tab immediately shows whether Query History is currently enabled or disabled.

### Description
- Added a `Status` indicator UI (`TextBlock` named `QueryHistoryStatusIndicator`) to the Query History tab and implemented `IsQueryHistoryEnabled()` and `UpdateQueryHistoryStatusIndicator()` in the code-behind, and wired the updater into `UpdateQueryHistoryConnectionDetails()` and `UpdateQueryHistoryStorageControls()` so the status refreshes when storage type or connection details change, reusing `GetThemedStatusBrush()` for themed coloring.

### Testing
- Attempted `dotnet build AxialSqlTools.sln -v minimal` which failed because `dotnet` is not available in the environment, and no other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e53709d9048333ae70234e0d2b6b3e)