### PR TITLE
Fix inline snippet replacement

### DIFF
--- a/AxialSqlTools/Modules/KeypressCommandFilter.cs
+++ b/AxialSqlTools/Modules/KeypressCommandFilter.cs
@@ -92,12 +92,11 @@ namespace AxialSqlTools
             if (textView.GetBuffer(out IVsTextLines textLines) != VSConstants.S_OK)
                 return;
 
-            if (!package.globalSnippets.TryGetValue(lineText.Trim(), out string newText))
-                return;        
-
             textView.GetCaretPos(out int iLine, out int iIndex);
 
-            int iSourceLength = lineText.Length;
+            if (!TryGetSnippetReplacement(lineText, iIndex, out int snippetStartIndex, out int snippetEndIndex, out string newText))
+                return;
+
             int iTargetLength = newText.Length;
 
             TextSpan[] pChangedSpan = new TextSpan[] { };
@@ -106,13 +105,61 @@ namespace AxialSqlTools
 
             try
             {
-                textLines.ReplaceLines(iLine, 0, iLine, iSourceLength, pNewText, iTargetLength, pChangedSpan);
+                textLines.ReplaceLines(iLine, snippetStartIndex, iLine, snippetEndIndex, pNewText, iTargetLength, pChangedSpan);
             }
             finally
             {
                 Marshal.FreeHGlobal(pNewText);
             }
 
+        }
+
+        private bool TryGetSnippetReplacement(string lineText, int caretIndex, out int snippetStartIndex, out int snippetEndIndex, out string newText)
+        {
+            snippetStartIndex = -1;
+            snippetEndIndex = -1;
+            newText = null;
+
+            if (string.IsNullOrEmpty(lineText) || package?.globalSnippets == null || package.globalSnippets.Count == 0)
+                return false;
+
+            int searchEndIndex = Math.Min(Math.Max(caretIndex, 0), lineText.Length);
+
+            while (searchEndIndex > 0 && char.IsWhiteSpace(lineText[searchEndIndex - 1]))
+            {
+                searchEndIndex--;
+            }
+
+            if (searchEndIndex == 0)
+                return false;
+
+            foreach (KeyValuePair<string, string> snippet in package.globalSnippets)
+            {
+                string snippetName = snippet.Key;
+
+                if (string.IsNullOrWhiteSpace(snippetName))
+                    continue;
+
+                int candidateStartIndex = searchEndIndex - snippetName.Length;
+
+                if (candidateStartIndex < 0)
+                    continue;
+
+                if (candidateStartIndex > 0 && !char.IsWhiteSpace(lineText[candidateStartIndex - 1]))
+                    continue;
+
+                if (!string.Equals(lineText.Substring(candidateStartIndex, snippetName.Length), snippetName, StringComparison.Ordinal))
+                    continue;
+
+                if (newText != null && snippetName.Length <= snippetEndIndex - snippetStartIndex)
+                    continue;
+
+                snippetStartIndex = candidateStartIndex;
+                snippetEndIndex = searchEndIndex;
+                newText = snippet.Value;
+            }
+
+            return newText != null;
         }
 
         public int QueryStatus(ref Guid cmdGroup, uint cCmds, OLECMD[] prgCmds, IntPtr pCmdText)


### PR DESCRIPTION
### Motivation
- Snippets were only being replaced when the entire line exactly matched a snippet name, preventing inline replacements like `MyTable nl` → `MyTable WITH (NOLOCK) `. 
- The goal is to allow snippet expansion for tokens immediately before the caret while preserving surrounding text and allowing trailing whitespace.

### Description
- Replace snippet handling in `AxialSqlTools/Modules/KeypressCommandFilter.cs` to use the caret position and a new `TryGetSnippetReplacement` helper instead of matching the whole line.
- `TryGetSnippetReplacement` scans backward from the caret ignoring trailing whitespace, enforces a whitespace boundary before the snippet token, selects the longest matching snippet, and returns the exact start/end indices and replacement text.
- `ReplaceSnippetText` now calls `TryGetSnippetReplacement` and invokes `textLines.ReplaceLines` with `snippetStartIndex`/`snippetEndIndex` so only the token is replaced and surrounding text is preserved.
- Added a guard for empty `lineText` and for missing/empty snippet map (`package.globalSnippets`).

### Testing
- Ran `git diff --check` which completed without issues. 
- Attempted `dotnet build AxialSqlTools/AxialSqlTools.sln` but it could not be executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff68d912e4833396b35c0f7a9d71b9)