### PR TITLE
Fix connection color rule list binding

### DIFF
--- a/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml.cs
+++ b/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml.cs
@@ -56,6 +56,9 @@ as select 1;
         {
             this.InitializeComponent();
 
+            _connectionColorRules = new ObservableCollection<SettingsManager.ConnectionColorRule>();
+            ConnectionColorRulesListView.ItemsSource = _connectionColorRules;
+
             _themeController = new ToolWindowThemeController(this, ApplyThemeBrushResources);
 
             this.Loaded += UserControl_Loaded;
@@ -190,6 +193,8 @@ as select 1;
 
                 EnableUpdateChecks.IsChecked = SettingsManager.GetEnableUpdateChecks();
                 UpdateUpdateStatus();
+
+                LoadConnectionColorRules();
 
             }
             catch (Exception ex)
@@ -743,6 +748,21 @@ END
             }
         }
 
+        private void LoadConnectionColorRules()
+        {
+            _connectionColorRules = new ObservableCollection<SettingsManager.ConnectionColorRule>(SettingsManager.GetConnectionColorRules());
+            ConnectionColorRulesListView.ItemsSource = _connectionColorRules;
+        }
+
+        private void EnsureConnectionColorRulesLoaded()
+        {
+            if (_connectionColorRules == null)
+            {
+                _connectionColorRules = new ObservableCollection<SettingsManager.ConnectionColorRule>();
+                ConnectionColorRulesListView.ItemsSource = _connectionColorRules;
+            }
+        }
+
         private string PickColor(string currentHex)
         {
             var dialog = new System.Windows.Forms.ColorDialog();
@@ -800,6 +820,8 @@ END
 
         private void ButtonAddColorRule_Click(object sender, RoutedEventArgs e)
         {
+            EnsureConnectionColorRulesLoaded();
+
             string serverPattern = NewRuleServerPattern.Text?.Trim();
             string databasePattern = NewRuleDatabasePattern.Text?.Trim();
 


### PR DESCRIPTION
### Motivation
- The Connection Colors view did not reflect newly added rules because the `ListView` had no bound item source when the control was created or when rules were added.

### Description
- Initialize an `ObservableCollection<SettingsManager.ConnectionColorRule>` and set `ConnectionColorRulesListView.ItemsSource` in the control constructor so the Configured Rules view is immediately bound.
- Load persisted rules on settings load via a new `LoadConnectionColorRules()` method that populates the bound collection from `SettingsManager.GetConnectionColorRules()`.
- Add `EnsureConnectionColorRulesLoaded()` and call it from `ButtonAddColorRule_Click` so the add handler always updates the bound collection.

### Testing
- `git diff --check` was run and reported no issues.
- Attempts to build with `dotnet build AxialSqlTools/AxialSqlTools.sln --no-restore` and `msbuild AxialSqlTools/AxialSqlTools.sln /p:RestorePackages=false` were not executed due to the build tools not being available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a035b9be4bc83338fd1d9ef7d6eeaec)