### PR TITLE
Support Microsoft Entra auth in Data Transfer connections

### DIFF
--- a/AxialSqlTools/DataImport/DataImportWindowControl.xaml.cs
+++ b/AxialSqlTools/DataImport/DataImportWindowControl.xaml.cs
@@ -4,7 +4,7 @@
     using Microsoft.Win32;
     using System;
     using System.Collections.Generic;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.IO;
     using System.Linq;
     using System.Text;

--- a/AxialSqlTools/DataTransfer/DataTransferWindowControl.xaml.cs
+++ b/AxialSqlTools/DataTransfer/DataTransferWindowControl.xaml.cs
@@ -55,14 +55,14 @@
             /// </summary>
             /// <param name="bulkCopy">The bulk copy.</param>
             /// <returns></returns>
-            public static int GetRowsCopied(SqlBulkCopy bulkCopy)
+            public static Int64 GetRowsCopied(SqlBulkCopy bulkCopy)
             {
                 if (rowsCopiedField == null)
                 {
                     rowsCopiedField = typeof(SqlBulkCopy).GetField("_rowsCopied", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
                 }
 
-                return (int)rowsCopiedField.GetValue(bulkCopy);
+                return (Int64)rowsCopiedField.GetValue(bulkCopy);
             }
         }
 
@@ -255,7 +255,7 @@
                 {
 
                     int batchSize = 10000;
-                    int totalRowsCopied = 0;
+                    long totalRowsCopied = 0;
 
                     TextRange textRange = new TextRange(RichTextBox_SourceQuery.Document.ContentStart, RichTextBox_SourceQuery.Document.ContentEnd);
                     string sourceQuery = textRange.Text;
@@ -1016,7 +1016,7 @@
 
                                         await bulkCopy.WriteToServerAsync(reader, cancellationToken);
 
-                                        int totalRowsCopied = SqlBulkCopyHelper.GetRowsCopied(bulkCopy);
+                                        long totalRowsCopied = SqlBulkCopyHelper.GetRowsCopied(bulkCopy);
                                         TimeSpan ts = stopwatch.Elapsed;
                                         Label_CopyProgressFromPsql.Content = $"Completed | Total rows copied: {totalRowsCopied:#,0} in {(int)ts.TotalSeconds:#,0} sec.";
                                     }
@@ -1159,7 +1159,7 @@
 
                                         await bulkCopy.WriteToServerAsync(reader, cancellationToken);
 
-                                        int totalRowsCopied = SqlBulkCopyHelper.GetRowsCopied(bulkCopy);
+                                        long totalRowsCopied = SqlBulkCopyHelper.GetRowsCopied(bulkCopy);
                                         TimeSpan ts = stopwatch.Elapsed;
                                         Label_CopyProgressFromMySql.Content = $"Completed | Total rows copied: {totalRowsCopied:#,0} in {(int)ts.TotalSeconds:#,0} sec.";
                                     }

--- a/AxialSqlTools/DataTransfer/DataTransferWindowControl.xaml.cs
+++ b/AxialSqlTools/DataTransfer/DataTransferWindowControl.xaml.cs
@@ -6,7 +6,7 @@
     using System;
     using System.Collections.Generic;
     using System.Data;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Tracing;

--- a/AxialSqlTools/GridToEmail/ToolWindowGridToEmailControl.xaml.cs
+++ b/AxialSqlTools/GridToEmail/ToolWindowGridToEmailControl.xaml.cs
@@ -4,7 +4,7 @@
     using System;
     using System.Collections.Generic;
     using System.Data;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Net;

--- a/AxialSqlTools/HealthDashboards/HealthDashboard_ServerControl.xaml.cs
+++ b/AxialSqlTools/HealthDashboards/HealthDashboard_ServerControl.xaml.cs
@@ -4,7 +4,7 @@
     using Microsoft.SqlServer.Management.UI.VSIntegration;
     using Microsoft.VisualStudio.Shell;
     using System;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Diagnostics.CodeAnalysis;
     using System.Threading;
     using System.Threading.Tasks;

--- a/AxialSqlTools/Modules/MetricsService.cs
+++ b/AxialSqlTools/Modules/MetricsService.cs
@@ -1,7 +1,7 @@
 ﻿
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Diagnostics;
 using System.Threading.Tasks;
 

--- a/AxialSqlTools/Modules/ScriptFactoryAccess.cs
+++ b/AxialSqlTools/Modules/ScriptFactoryAccess.cs
@@ -5,7 +5,7 @@ using Microsoft.SqlServer.Management.UI.VSIntegration.ObjectExplorer;
 using Microsoft.SqlServer.Management.Common;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -69,16 +69,25 @@ namespace AxialSqlTools
                 }
             }
 
-            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
-            builder.DataSource = selectedNode.Connection.ServerName;
-            builder.InitialCatalog = databaseName;
-            builder.UserID = selectedNode.Connection.UserName;
-            builder.IntegratedSecurity = string.IsNullOrEmpty(selectedNode.Connection.Password);
-            builder.Password = selectedNode.Connection.Password;
-            builder.ApplicationName = "Axial SQL Tools";
-            builder.Encrypt = ((SqlConnectionInfo)selectedNode.Connection).EncryptConnection;
-            builder.TrustServerCertificate = ((SqlConnectionInfo)selectedNode.Connection).TrustServerCertificate;
+            var objectExplorerConnection = selectedNode.Connection;
+            string userName = objectExplorerConnection.UserName;
+            string password = objectExplorerConnection.Password;
+            string auth = GetAuthenticationMode(objectExplorerConnection);
 
+            var builder = new SqlConnectionStringBuilder
+            {
+                DataSource = objectExplorerConnection.ServerName,
+                InitialCatalog = databaseName,
+                ApplicationName = "Axial SQL Tools"
+            };
+
+            ApplyAuthentication(builder, userName, password, auth);
+
+            if (objectExplorerConnection is SqlConnectionInfo sqlConnectionInfo)
+            {
+                builder.Encrypt = sqlConnectionInfo.EncryptConnection;
+                builder.TrustServerCertificate = sqlConnectionInfo.TrustServerCertificate;
+            }
 
             ConnectionInfo ci = new ConnectionInfo();
             ci.FullConnectionString = builder.ToString();
@@ -112,26 +121,7 @@ namespace AxialSqlTools
 
             string auth = GetAuthenticationMode(connection);
 
-            if (ShouldUseMicrosoftEntraInteractive(connection, auth))
-            {
-                builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryInteractive;
-
-                if (!string.IsNullOrWhiteSpace(connection.UserName))
-                    builder.UserID = connection.UserName;
-
-                // Do not set Password for Microsoft Entra MFA.
-                // Do not set IntegratedSecurity=True, because that triggers SSPI/Kerberos.
-            }
-            else if (!string.IsNullOrWhiteSpace(connection.Password))
-            {
-                builder.IntegratedSecurity = false;
-                builder.UserID = connection.UserName;
-                builder.Password = connection.Password;
-            }
-            else
-            {
-                builder.IntegratedSecurity = true;
-            }
+            ApplyAuthentication(builder, connection.UserName, connection.Password, auth);
 
             if (IsTrue(GetAdvancedOption(connection, "ENCRYPT_CONNECTION")))
                 builder.Encrypt = true;
@@ -184,20 +174,125 @@ namespace AxialSqlTools
             return string.Join(";", values);
         }
 
-        private static bool ShouldUseMicrosoftEntraInteractive(UIConnectionInfo connection, string auth)
+        private static string GetAuthenticationMode(object connection)
+        {
+            if (connection == null)
+                return string.Empty;
+
+            var values = new List<string>();
+
+            AddPropertyValue(connection, "Authentication", values);
+            AddPropertyValue(connection, "AuthenticationMethod", values);
+            AddPropertyValue(connection, "AuthenticationType", values);
+            AddPropertyValue(connection, "ConnectionString", values);
+
+            return string.Join(";", values);
+        }
+
+        private static void AddPropertyValue(object instance, string propertyName, List<string> values)
+        {
+            var property = instance.GetType().GetProperty(propertyName);
+            if (property == null)
+                return;
+
+            object value = null;
+            try
+            {
+                value = property.GetValue(instance, null);
+            }
+            catch
+            {
+                return;
+            }
+
+            if (value == null)
+                return;
+
+            string text = value.ToString();
+            if (!string.IsNullOrWhiteSpace(text))
+                values.Add(text);
+        }
+
+        private static void ApplyAuthentication(SqlConnectionStringBuilder builder, string userName, string password, string auth)
+        {
+            SqlAuthenticationMethod? authenticationMethod = GetSqlAuthenticationMethod(auth, userName, password);
+
+            if (authenticationMethod.HasValue)
+            {
+                builder.Authentication = authenticationMethod.Value;
+
+                if (!string.IsNullOrWhiteSpace(userName))
+                    builder.UserID = userName;
+
+                if (ShouldSendPassword(authenticationMethod.Value) && !string.IsNullOrWhiteSpace(password))
+                    builder.Password = password;
+
+                // Do not set IntegratedSecurity=True for Microsoft Entra.
+                // Active Directory / Microsoft Entra authentication is mutually exclusive with SSPI/Kerberos.
+            }
+            else if (!string.IsNullOrWhiteSpace(password))
+            {
+                builder.IntegratedSecurity = false;
+                builder.UserID = userName;
+                builder.Password = password;
+            }
+            else
+            {
+                builder.IntegratedSecurity = true;
+            }
+        }
+
+        private static SqlAuthenticationMethod? GetSqlAuthenticationMethod(string auth, string userName, string password)
+        {
+            if (ContainsAny(auth, "Active Directory Password", "ActiveDirectoryPassword", "Microsoft Entra Password", "Azure Active Directory Password"))
+                return SqlAuthenticationMethod.ActiveDirectoryPassword;
+
+            if (ContainsAny(auth, "Active Directory Integrated", "ActiveDirectoryIntegrated", "Microsoft Entra Integrated", "Azure Active Directory Integrated"))
+                return SqlAuthenticationMethod.ActiveDirectoryIntegrated;
+
+            if (ContainsAny(auth, "Active Directory Default", "ActiveDirectoryDefault", "Microsoft Entra Default", "Azure Active Directory Default"))
+                return SqlAuthenticationMethod.ActiveDirectoryDefault;
+
+            if (ShouldUseMicrosoftEntraInteractive(userName, password, auth))
+                return SqlAuthenticationMethod.ActiveDirectoryInteractive;
+
+            return null;
+        }
+
+        private static bool ShouldSendPassword(SqlAuthenticationMethod authenticationMethod)
+        {
+            return authenticationMethod == SqlAuthenticationMethod.ActiveDirectoryPassword ||
+                   authenticationMethod == SqlAuthenticationMethod.SqlPassword;
+        }
+
+        private static bool ContainsAny(string value, params string[] tokens)
+        {
+            if (string.IsNullOrWhiteSpace(value) || tokens == null)
+                return false;
+
+            foreach (string token in tokens)
+            {
+                if (!string.IsNullOrWhiteSpace(token) &&
+                    value.IndexOf(token, StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool ShouldUseMicrosoftEntraInteractive(string userName, string password, string auth)
         {
             if (IsMicrosoftEntraMfa(auth))
                 return true;
 
-            if (connection == null)
-                return false;
-
-            bool hasUserName = !string.IsNullOrWhiteSpace(connection.UserName);
-            bool hasPassword = !string.IsNullOrWhiteSpace(connection.Password);
+            bool hasUserName = !string.IsNullOrWhiteSpace(userName);
+            bool hasPassword = !string.IsNullOrWhiteSpace(password);
 
             // Microsoft Entra MFA commonly has a UPN username and no password.
             // This prevents accidental fallback to Integrated Security=True / SSPI.
-            if (hasUserName && !hasPassword && LooksLikeUpn(connection.UserName))
+            if (hasUserName && !hasPassword && LooksLikeUpn(userName))
                 return true;
 
             return false;


### PR DESCRIPTION
### Motivation
- Ensure the Data Transfer UI and related connection helpers honor Microsoft Entra / Azure AD authentication modes so interactive/MFA and other Entra flows work when selecting source/target SQL Server connections.

### Description
- Switched SQL client using directive in the Data Transfer window to `Microsoft.Data.SqlClient` to allow Entra-related connection-string/authentication features. (file: `DataTransfer/DataTransferWindowControl.xaml.cs`)
- Centralized and extended authentication handling in `ScriptFactoryAccess` by adding reflection-based extraction of authentication metadata and helper functions: `GetAuthenticationMode(object)`, `AddPropertyValue`, `ApplyAuthentication`, `GetSqlAuthenticationMethod`, `ContainsAny`, `ShouldSendPassword`, and an updated interactive-detection `ShouldUseMicrosoftEntraInteractive` to decide when to use `SqlAuthenticationMethod.ActiveDirectoryInteractive`. (file: `Modules/ScriptFactoryAccess.cs`)
- Updated object-explorer connection string construction to call the new `ApplyAuthentication` flow and preserve `Encrypt`/`TrustServerCertificate` when available, while avoiding accidental `IntegratedSecurity=True` for Entra interactive/MFA flows. (file: `Modules/ScriptFactoryAccess.cs`)
- Broadened token/keyword detection to recognize both “Microsoft Entra” and common Azure AD/Active Directory authentication keywords so various connection string/property patterns are handled.

### Testing
- Ran `git diff --check` to verify no whitespace/patch errors, which completed with no issues.
- Attempted `dotnet build AxialSqlTools/AxialSqlTools.sln` but the `dotnet` CLI is not available in the environment so a full build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09cba5406883339f902f3d143864b7)