### PR TITLE
Improve statistics summary reliability and add two-result comparison view

### DIFF
--- a/AxialSqlTools/AxialSqlToolsPackage.cs
+++ b/AxialSqlTools/AxialSqlToolsPackage.cs
@@ -525,7 +525,7 @@ namespace AxialSqlTools
             try
             {
                 var sqlResultsControl = GridAccess.GetNonPublicField(Window.Object, "m_sqlResultsControl");
-                AttachStatisticsExecutionCompletedHandler(sqlResultsControl, "window-created");
+                AttachStatisticsExecutionCompletedHandler(sqlResultsControl);
 
             }
             catch (Exception ex) 
@@ -534,7 +534,7 @@ namespace AxialSqlTools
             }
         }
 
-        private static void AttachStatisticsExecutionCompletedHandler(object sqlResultsControl, string reason)
+        private static void AttachStatisticsExecutionCompletedHandler(object sqlResultsControl)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
@@ -563,7 +563,7 @@ namespace AxialSqlTools
             try
             {
                 var sqlResultsControl = GridAccess.GetSQLResultsControl();
-                AttachStatisticsExecutionCompletedHandler(sqlResultsControl, reason);
+                AttachStatisticsExecutionCompletedHandler(sqlResultsControl);
             }
             catch (Exception ex)
             {
@@ -875,7 +875,7 @@ namespace AxialSqlTools
 
                 GridAccess.TryFlushStatisticsMessages();
 
-                var statisticsText = GridAccess.TryGetStatisticsMessagesText(sqlExecutionContext);
+                var statisticsText = GridAccess.TryGetStatisticsMessagesText();
                 if (TryStoreStatisticsSummary(sqlExecutionContext, statisticsText, captureVersion, out var summary))
                 {
                     return;

--- a/AxialSqlTools/AxialSqlToolsPackage.cs
+++ b/AxialSqlTools/AxialSqlToolsPackage.cs
@@ -863,9 +863,13 @@ namespace AxialSqlTools
         {
             const int maxAttempts = 3;
 
-            if (!HasStatisticsSummaryOutputEnabled(sqlExecutionContext))
+            cancellationToken.ThrowIfCancellationRequested();
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var statisticsOutputOptions = GetStatisticsSummaryOutputOptions(sqlExecutionContext);
+            if (!statisticsOutputOptions.HasStatisticsOutput)
             {
-                StatisticsSummaryStore.MarkUnavailable(captureVersion);
+                StatisticsSummaryStore.MarkUnavailable(captureVersion, StatisticsSummaryCaptureStatus.StatisticsDisabled);
                 return;
             }
 
@@ -896,21 +900,33 @@ namespace AxialSqlTools
             StatisticsSummaryStore.MarkUnavailable(captureVersion);
         }
 
-        private static bool HasStatisticsSummaryOutputEnabled(object sqlExecutionContext)
+        private sealed class StatisticsSummaryOutputOptions
         {
+            public bool StatisticsIoEnabled { get; set; }
+            public bool StatisticsTimeEnabled { get; set; }
+            public bool HasStatisticsOutput => StatisticsIoEnabled || StatisticsTimeEnabled;
+        }
+
+        private static StatisticsSummaryOutputOptions GetStatisticsSummaryOutputOptions(object sqlExecutionContext)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             try
             {
                 if (!(GridAccess.GetNonPublicField(sqlExecutionContext, "m_conn") is SqlConnection connection)
                     || connection.State != ConnectionState.Open)
                 {
-                    return true;
+                    return new StatisticsSummaryOutputOptions
+                    {
+                        StatisticsIoEnabled = true,
+                        StatisticsTimeEnabled = true,
+                    };
                 }
 
                 using (var command = new SqlCommand("DBCC USEROPTIONS WITH NO_INFOMSGS;", connection))
                 using (var reader = command.ExecuteReader())
                 {
-                    var statisticsIoEnabled = false;
-                    var statisticsTimeEnabled = false;
+                    var options = new StatisticsSummaryOutputOptions();
 
                     while (reader.Read())
                     {
@@ -928,26 +944,25 @@ namespace AxialSqlTools
 
                         if (optionName.Equals("statistics io", StringComparison.OrdinalIgnoreCase))
                         {
-                            statisticsIoEnabled = IsUserOptionEnabled(optionValue);
+                            options.StatisticsIoEnabled = IsUserOptionEnabled(optionValue);
                         }
                         else if (optionName.Equals("statistics time", StringComparison.OrdinalIgnoreCase))
                         {
-                            statisticsTimeEnabled = IsUserOptionEnabled(optionValue);
-                        }
-
-                        if (statisticsIoEnabled || statisticsTimeEnabled)
-                        {
-                            return true;
+                            options.StatisticsTimeEnabled = IsUserOptionEnabled(optionValue);
                         }
                     }
 
-                    return statisticsIoEnabled || statisticsTimeEnabled;
+                    return options;
                 }
             }
             catch (Exception ex)
             {
                 _logger.Error(ex, "Failed to inspect session statistics options.");
-                return true;
+                return new StatisticsSummaryOutputOptions
+                {
+                    StatisticsIoEnabled = true,
+                    StatisticsTimeEnabled = true,
+                };
             }
         }
 

--- a/AxialSqlTools/AxialSqlToolsPackage.cs
+++ b/AxialSqlTools/AxialSqlToolsPackage.cs
@@ -861,7 +861,13 @@ namespace AxialSqlTools
 
         private static async Task CaptureStatisticsSummaryAsync(object sqlExecutionContext, int captureVersion, CancellationToken cancellationToken)
         {
-            const int maxAttempts = 24;
+            const int maxAttempts = 3;
+
+            if (!HasStatisticsSummaryOutputEnabled(sqlExecutionContext))
+            {
+                StatisticsSummaryStore.MarkUnavailable(captureVersion);
+                return;
+            }
 
             for (int attempt = 0; attempt < maxAttempts; attempt++)
             {
@@ -883,11 +889,79 @@ namespace AxialSqlTools
 
                 if (attempt < maxAttempts - 1)
                 {
-                    await Task.Delay(300, cancellationToken);
+                    await Task.Delay(150, cancellationToken);
                 }
             }
 
             StatisticsSummaryStore.MarkUnavailable(captureVersion);
+        }
+
+        private static bool HasStatisticsSummaryOutputEnabled(object sqlExecutionContext)
+        {
+            try
+            {
+                if (!(GridAccess.GetNonPublicField(sqlExecutionContext, "m_conn") is SqlConnection connection)
+                    || connection.State != ConnectionState.Open)
+                {
+                    return true;
+                }
+
+                using (var command = new SqlCommand("DBCC USEROPTIONS WITH NO_INFOMSGS;", connection))
+                using (var reader = command.ExecuteReader())
+                {
+                    var statisticsIoEnabled = false;
+                    var statisticsTimeEnabled = false;
+
+                    while (reader.Read())
+                    {
+                        if (reader.FieldCount < 2)
+                        {
+                            continue;
+                        }
+
+                        var optionName = reader.IsDBNull(0) ? null : reader.GetString(0);
+                        var optionValue = reader.IsDBNull(1) ? null : reader.GetString(1);
+                        if (string.IsNullOrWhiteSpace(optionName))
+                        {
+                            continue;
+                        }
+
+                        if (optionName.Equals("statistics io", StringComparison.OrdinalIgnoreCase))
+                        {
+                            statisticsIoEnabled = IsUserOptionEnabled(optionValue);
+                        }
+                        else if (optionName.Equals("statistics time", StringComparison.OrdinalIgnoreCase))
+                        {
+                            statisticsTimeEnabled = IsUserOptionEnabled(optionValue);
+                        }
+
+                        if (statisticsIoEnabled || statisticsTimeEnabled)
+                        {
+                            return true;
+                        }
+                    }
+
+                    return statisticsIoEnabled || statisticsTimeEnabled;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Failed to inspect session statistics options.");
+                return true;
+            }
+        }
+
+        private static bool IsUserOptionEnabled(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            return value.Equals("on", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("set", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("true", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("1", StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool TryStoreStatisticsSummary(object sqlExecutionContext, string statisticsText, int captureVersion, out StatisticsSummary summary)

--- a/AxialSqlTools/Modules/GridAccess.cs
+++ b/AxialSqlTools/Modules/GridAccess.cs
@@ -654,23 +654,91 @@ namespace AxialSqlTools
             return dataTables;
         }
 
-        public static string TryGetStatisticsMessagesText(object executionContext = null)
+        public static string TryGetStatisticsMessagesText()
         {
-            var visited = new HashSet<object>(new ReferenceEqualityComparer());
-
-            if (TryFindStatisticsText(executionContext, 0, visited, out var statisticsText))
-            {
-                return statisticsText;
-            }
-
             var sqlResultsControl = GetSQLResultsControl();
-            if (!ReferenceEquals(sqlResultsControl, executionContext)
-                && TryFindStatisticsText(sqlResultsControl, 0, visited, out statisticsText))
+            return TryFindStatisticsTextFromResultsControl(sqlResultsControl, out var statisticsText) ? statisticsText : null;
+        }
+
+        private static bool TryFindStatisticsTextFromResultsControl(object sqlResultsControl, out string statisticsText)
+        {
+            statisticsText = null;
+
+            var resultsTabControl = GetNonPublicField(sqlResultsControl, "m_resultsTabCtrl") as TabControl;
+            if (resultsTabControl == null)
             {
-                return statisticsText;
+                return false;
             }
 
-            return null;
+            var selectedIndex = resultsTabControl.SelectedIndex;
+            var messagesIndex = FindMessagesTabIndex(resultsTabControl);
+
+            var visited = new HashSet<object>(new ReferenceEqualityComparer());
+            if (TryFindStatisticsText(resultsTabControl, 0, visited, out statisticsText))
+            {
+                return true;
+            }
+
+            if (messagesIndex < 0 || messagesIndex >= resultsTabControl.TabPages.Count)
+            {
+                return false;
+            }
+
+            try
+            {
+                if (resultsTabControl.SelectedIndex != messagesIndex)
+                {
+                    resultsTabControl.SelectedIndex = messagesIndex;
+                    resultsTabControl.Update();
+                    resultsTabControl.Refresh();
+                    Application.DoEvents();
+                    TryFlushStatisticsMessages();
+                }
+
+                visited.Clear();
+                if (TryFindStatisticsText(resultsTabControl.TabPages[messagesIndex], 0, visited, out statisticsText))
+                {
+                    return true;
+                }
+
+                visited.Clear();
+                return TryFindStatisticsText(resultsTabControl, 0, visited, out statisticsText);
+            }
+            finally
+            {
+                if (selectedIndex >= 0
+                    && selectedIndex < resultsTabControl.TabPages.Count
+                    && resultsTabControl.SelectedIndex != selectedIndex)
+                {
+                    try
+                    {
+                        resultsTabControl.SelectedIndex = selectedIndex;
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+        }
+
+        private static int FindMessagesTabIndex(TabControl tabControl)
+        {
+            if (tabControl == null)
+            {
+                return -1;
+            }
+
+            for (var index = 0; index < tabControl.TabPages.Count; index++)
+            {
+                var tabPageText = tabControl.TabPages[index]?.Text;
+                if (!string.IsNullOrWhiteSpace(tabPageText)
+                    && tabPageText.IndexOf("messages", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return index;
+                }
+            }
+
+            return tabControl.TabPages.Count > 1 ? 1 : -1;
         }
 
         public static void TryFlushStatisticsMessages()
@@ -909,7 +977,6 @@ namespace AxialSqlTools
                 return null;
             }
         }
-
 
         private static void TryFlushWriterLike(object writer)
         {

--- a/AxialSqlTools/StatisticsSummary/StatisticsSummaryParser.cs
+++ b/AxialSqlTools/StatisticsSummary/StatisticsSummaryParser.cs
@@ -10,6 +10,10 @@ namespace AxialSqlTools
             @"Table\s+'(?<name>[^']+)'\.\s*(?<metrics>.+)",
             RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+        private static readonly Regex GeneratedTempTableSuffixRegex = new Regex(
+            @"_+[0-9A-Fa-f]{12}$",
+            RegexOptions.Compiled);
+
         private static readonly Regex ScanCountRegex = new Regex(
             @"Scan count\s+(?<value>\d[\d,]*)",
             RegexOptions.IgnoreCase | RegexOptions.Compiled);
@@ -37,7 +41,7 @@ namespace AxialSqlTools
             var tablesByName = new Dictionary<string, StatisticsTableSummary>(StringComparer.OrdinalIgnoreCase);
             foreach (Match match in TableLineRegex.Matches(text))
             {
-                var tableName = match.Groups["name"].Value;
+                var tableName = FormatTableName(match.Groups["name"].Value);
                 if (!tablesByName.TryGetValue(tableName, out var tableSummary))
                 {
                     tableSummary = new StatisticsTableSummary
@@ -85,6 +89,16 @@ namespace AxialSqlTools
             }
 
             return summary.HasData ? summary : null;
+        }
+
+        private static string FormatTableName(string tableName)
+        {
+            if (string.IsNullOrEmpty(tableName) || tableName[0] != '#' || (tableName.Length > 1 && tableName[1] == '#'))
+            {
+                return tableName;
+            }
+
+            return GeneratedTempTableSuffixRegex.Replace(tableName, string.Empty);
         }
 
         private static long ParseLong(string value)

--- a/AxialSqlTools/StatisticsSummary/StatisticsSummaryStore.cs
+++ b/AxialSqlTools/StatisticsSummary/StatisticsSummaryStore.cs
@@ -4,49 +4,71 @@ using System.Linq;
 
 namespace AxialSqlTools
 {
-    internal sealed class StatisticsSummaryStoreState
+    internal enum StatisticsSummaryCaptureStatus
+    {
+        None,
+        Loading,
+        Success,
+        Failed,
+        StatisticsDisabled,
+    }
+
+    internal sealed class StatisticsSummaryStoreResult
     {
         public StatisticsSummary Summary { get; set; }
-        public IReadOnlyList<StatisticsSummary> Summaries { get; set; }
-        public bool IsLoading { get; set; }
-        public bool LastCaptureFailed { get; set; }
+        public StatisticsSummaryCaptureStatus Status { get; set; }
+    }
+
+    internal sealed class StatisticsSummaryStoreState
+    {
+        internal StatisticsSummary Summary { get; set; }
+        internal IReadOnlyList<StatisticsSummary> Summaries { get; set; }
+        internal IReadOnlyList<StatisticsSummaryStoreResult> Results { get; set; }
+        internal bool IsLoading { get; set; }
+        internal bool LastCaptureFailed { get; set; }
     }
 
     internal static class StatisticsSummaryStore
     {
         private static readonly object SyncRoot = new object();
-        private static readonly List<StatisticsSummary> Summaries = new List<StatisticsSummary>();
+        private static readonly List<StatisticsSummaryStoreResult> Results = new List<StatisticsSummaryStoreResult>();
         private static bool _isLoading;
         private static bool _lastCaptureFailed;
         private static bool _isWindowOpen;
         private static int _activeCaptureVersion;
 
-        public static event EventHandler SummaryChanged;
+        internal static event EventHandler SummaryChanged;
 
-        public static StatisticsSummary GetCurrent()
+        internal static StatisticsSummary GetCurrent()
         {
             lock (SyncRoot)
             {
-                return Summaries.FirstOrDefault();
+                return Results.FirstOrDefault(result => result.Status == StatisticsSummaryCaptureStatus.Success)?.Summary;
             }
         }
 
-        public static StatisticsSummaryStoreState GetState()
+        internal static StatisticsSummaryStoreState GetState()
         {
             lock (SyncRoot)
             {
-                var summaries = Summaries.ToList();
+                var results = Results.Select(CloneResult).ToList();
+                var summaries = results
+                    .Where(result => result.Status == StatisticsSummaryCaptureStatus.Success && result.Summary != null)
+                    .Select(result => result.Summary)
+                    .ToList();
+
                 return new StatisticsSummaryStoreState
                 {
                     Summary = summaries.FirstOrDefault(),
                     Summaries = summaries,
+                    Results = results,
                     IsLoading = _isLoading,
                     LastCaptureFailed = _lastCaptureFailed,
                 };
             }
         }
 
-        public static bool IsWindowOpen()
+        internal static bool IsWindowOpen()
         {
             lock (SyncRoot)
             {
@@ -54,7 +76,7 @@ namespace AxialSqlTools
             }
         }
 
-        public static void SetWindowOpen(bool isWindowOpen)
+        internal static void SetWindowOpen(bool isWindowOpen)
         {
             var shouldRaise = false;
 
@@ -73,6 +95,7 @@ namespace AxialSqlTools
                     _isLoading = false;
                     _lastCaptureFailed = false;
                     _activeCaptureVersion++;
+                    RemoveLoadingResult();
                 }
             }
 
@@ -82,7 +105,7 @@ namespace AxialSqlTools
             }
         }
 
-        public static bool BeginCapture(int captureVersion)
+        internal static bool BeginCapture(int captureVersion)
         {
             lock (SyncRoot)
             {
@@ -94,13 +117,27 @@ namespace AxialSqlTools
                 _activeCaptureVersion = captureVersion;
                 _isLoading = true;
                 _lastCaptureFailed = false;
+
+                if (Results.Count == 0 || Results[0].Status != StatisticsSummaryCaptureStatus.Loading)
+                {
+                    Results.Insert(0, new StatisticsSummaryStoreResult
+                    {
+                        Status = StatisticsSummaryCaptureStatus.Loading,
+                    });
+                    TrimResults();
+                }
+                else
+                {
+                    Results[0].Summary = null;
+                    Results[0].Status = StatisticsSummaryCaptureStatus.Loading;
+                }
             }
 
             SummaryChanged?.Invoke(null, EventArgs.Empty);
             return true;
         }
 
-        public static void Set(StatisticsSummary summary, int captureVersion)
+        internal static void Set(StatisticsSummary summary, int captureVersion)
         {
             lock (SyncRoot)
             {
@@ -109,11 +146,7 @@ namespace AxialSqlTools
                     return;
                 }
 
-                Summaries.Insert(0, summary);
-                while (Summaries.Count > 2)
-                {
-                    Summaries.RemoveAt(Summaries.Count - 1);
-                }
+                SetActiveResult(summary, StatisticsSummaryCaptureStatus.Success);
 
                 _isLoading = false;
                 _lastCaptureFailed = false;
@@ -122,7 +155,12 @@ namespace AxialSqlTools
             SummaryChanged?.Invoke(null, EventArgs.Empty);
         }
 
-        public static void MarkUnavailable(int captureVersion)
+        internal static void MarkUnavailable(int captureVersion)
+        {
+            MarkUnavailable(captureVersion, StatisticsSummaryCaptureStatus.Failed);
+        }
+
+        internal static void MarkUnavailable(int captureVersion, StatisticsSummaryCaptureStatus status)
         {
             lock (SyncRoot)
             {
@@ -131,6 +169,7 @@ namespace AxialSqlTools
                     return;
                 }
 
+                SetActiveResult(null, status);
                 _isLoading = false;
                 _lastCaptureFailed = true;
             }
@@ -138,23 +177,24 @@ namespace AxialSqlTools
             SummaryChanged?.Invoke(null, EventArgs.Empty);
         }
 
-        public static void CancelCapture()
+        internal static void CancelCapture()
         {
             lock (SyncRoot)
             {
                 _isLoading = false;
                 _lastCaptureFailed = false;
                 _activeCaptureVersion++;
+                RemoveLoadingResult();
             }
 
             SummaryChanged?.Invoke(null, EventArgs.Empty);
         }
 
-        public static void Clear()
+        internal static void Clear()
         {
             lock (SyncRoot)
             {
-                Summaries.Clear();
+                Results.Clear();
                 _isLoading = false;
                 _lastCaptureFailed = false;
                 _isWindowOpen = false;
@@ -162,6 +202,43 @@ namespace AxialSqlTools
             }
 
             SummaryChanged?.Invoke(null, EventArgs.Empty);
+        }
+
+        private static void SetActiveResult(StatisticsSummary summary, StatisticsSummaryCaptureStatus status)
+        {
+            if (Results.Count == 0)
+            {
+                Results.Insert(0, new StatisticsSummaryStoreResult());
+            }
+
+            Results[0].Summary = summary;
+            Results[0].Status = status;
+            TrimResults();
+        }
+
+        private static void RemoveLoadingResult()
+        {
+            if (Results.Count > 0 && Results[0].Status == StatisticsSummaryCaptureStatus.Loading)
+            {
+                Results.RemoveAt(0);
+            }
+        }
+
+        private static void TrimResults()
+        {
+            while (Results.Count > 2)
+            {
+                Results.RemoveAt(Results.Count - 1);
+            }
+        }
+
+        private static StatisticsSummaryStoreResult CloneResult(StatisticsSummaryStoreResult result)
+        {
+            return new StatisticsSummaryStoreResult
+            {
+                Summary = result.Summary,
+                Status = result.Status,
+            };
         }
     }
 }

--- a/AxialSqlTools/StatisticsSummary/StatisticsSummaryStore.cs
+++ b/AxialSqlTools/StatisticsSummary/StatisticsSummaryStore.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace AxialSqlTools
 {
     internal sealed class StatisticsSummaryStoreState
     {
         public StatisticsSummary Summary { get; set; }
+        public IReadOnlyList<StatisticsSummary> Summaries { get; set; }
         public bool IsLoading { get; set; }
         public bool LastCaptureFailed { get; set; }
     }
@@ -12,7 +15,7 @@ namespace AxialSqlTools
     internal static class StatisticsSummaryStore
     {
         private static readonly object SyncRoot = new object();
-        private static StatisticsSummary _current;
+        private static readonly List<StatisticsSummary> Summaries = new List<StatisticsSummary>();
         private static bool _isLoading;
         private static bool _lastCaptureFailed;
         private static bool _isWindowOpen;
@@ -24,7 +27,7 @@ namespace AxialSqlTools
         {
             lock (SyncRoot)
             {
-                return _current;
+                return Summaries.FirstOrDefault();
             }
         }
 
@@ -32,9 +35,11 @@ namespace AxialSqlTools
         {
             lock (SyncRoot)
             {
+                var summaries = Summaries.ToList();
                 return new StatisticsSummaryStoreState
                 {
-                    Summary = _current,
+                    Summary = summaries.FirstOrDefault(),
+                    Summaries = summaries,
                     IsLoading = _isLoading,
                     LastCaptureFailed = _lastCaptureFailed,
                 };
@@ -104,7 +109,12 @@ namespace AxialSqlTools
                     return;
                 }
 
-                _current = summary;
+                Summaries.Insert(0, summary);
+                while (Summaries.Count > 2)
+                {
+                    Summaries.RemoveAt(Summaries.Count - 1);
+                }
+
                 _isLoading = false;
                 _lastCaptureFailed = false;
             }
@@ -144,7 +154,7 @@ namespace AxialSqlTools
         {
             lock (SyncRoot)
             {
-                _current = null;
+                Summaries.Clear();
                 _isLoading = false;
                 _lastCaptureFailed = false;
                 _isWindowOpen = false;

--- a/AxialSqlTools/StatisticsSummary/StatisticsSummaryViewModel.cs
+++ b/AxialSqlTools/StatisticsSummary/StatisticsSummaryViewModel.cs
@@ -5,189 +5,50 @@ using System.Linq;
 
 namespace AxialSqlTools
 {
-    public class StatisticsSummaryViewModel : INotifyPropertyChanged
+    public class StatisticsSummaryResultViewModel
     {
+        public string Title { get; set; }
+        public bool ShowDivider { get; set; }
         public ObservableCollection<StatisticsTableSummary> Tables { get; } = new ObservableCollection<StatisticsTableSummary>();
+        public string CapturedAtText { get; set; }
+        public string SourceText { get; set; }
+        public string TotalReadsText { get; set; }
+        public string TotalElapsedText { get; set; }
+        public string TotalCpuText { get; set; }
+        public string QueryTextPreview { get; set; }
+        public bool HasTableData => Tables.Count > 0;
 
-        private bool _isLoading;
-        public bool IsLoading
+        public static StatisticsSummaryResultViewModel Create(string title, StatisticsSummary summary, bool showDivider)
         {
-            get => _isLoading;
-            set
+            var result = new StatisticsSummaryResultViewModel
             {
-                if (_isLoading != value)
-                {
-                    _isLoading = value;
-                    OnPropertyChanged(nameof(IsLoading));
-                }
-            }
-        }
+                Title = title,
+                ShowDivider = showDivider,
+                CapturedAtText = "-",
+                SourceText = "-",
+                TotalReadsText = "0",
+                TotalElapsedText = "-",
+                TotalCpuText = "-",
+                QueryTextPreview = string.Empty,
+            };
 
-        private string _statusMessage;
-        public string StatusMessage
-        {
-            get => _statusMessage;
-            set
-            {
-                if (_statusMessage != value)
-                {
-                    _statusMessage = value;
-                    OnPropertyChanged(nameof(StatusMessage));
-                }
-            }
-        }
-
-        private string _capturedAtText;
-        public string CapturedAtText
-        {
-            get => _capturedAtText;
-            set
-            {
-                if (_capturedAtText != value)
-                {
-                    _capturedAtText = value;
-                    OnPropertyChanged(nameof(CapturedAtText));
-                }
-            }
-        }
-
-        private string _sourceText;
-        public string SourceText
-        {
-            get => _sourceText;
-            set
-            {
-                if (_sourceText != value)
-                {
-                    _sourceText = value;
-                    OnPropertyChanged(nameof(SourceText));
-                }
-            }
-        }
-
-        private string _totalReadsText;
-        public string TotalReadsText
-        {
-            get => _totalReadsText;
-            set
-            {
-                if (_totalReadsText != value)
-                {
-                    _totalReadsText = value;
-                    OnPropertyChanged(nameof(TotalReadsText));
-                }
-            }
-        }
-
-        private string _totalElapsedText;
-        public string TotalElapsedText
-        {
-            get => _totalElapsedText;
-            set
-            {
-                if (_totalElapsedText != value)
-                {
-                    _totalElapsedText = value;
-                    OnPropertyChanged(nameof(TotalElapsedText));
-                }
-            }
-        }
-
-        private string _totalCpuText;
-        public string TotalCpuText
-        {
-            get => _totalCpuText;
-            set
-            {
-                if (_totalCpuText != value)
-                {
-                    _totalCpuText = value;
-                    OnPropertyChanged(nameof(TotalCpuText));
-                }
-            }
-        }
-
-        private string _queryTextPreview;
-        public string QueryTextPreview
-        {
-            get => _queryTextPreview;
-            set
-            {
-                if (_queryTextPreview != value)
-                {
-                    _queryTextPreview = value;
-                    OnPropertyChanged(nameof(QueryTextPreview));
-                }
-            }
-        }
-
-        public StatisticsSummaryViewModel()
-        {
-            RefreshFromStore();
-        }
-
-        public void RefreshFromStore()
-        {
-            var state = StatisticsSummaryStore.GetState();
-            var summary = state.Summary;
-            IsLoading = state.IsLoading;
-
-            Tables.Clear();
             if (summary == null || !summary.HasData)
             {
-                if (state.IsLoading)
-                {
-                    StatusMessage = "Loading latest statistics output...";
-                }
-                else if (state.LastCaptureFailed)
-                {
-                    StatusMessage = "The last execution did not expose SET STATISTICS IO/TIME output before the retry window expired.";
-                }
-                else
-                {
-                    StatusMessage = "No SET STATISTICS IO/TIME output was captured for the last execution.";
-                }
-
-                CapturedAtText = "-";
-                SourceText = "-";
-                TotalReadsText = "0";
-                TotalElapsedText = "-";
-                TotalCpuText = "-";
-                QueryTextPreview = string.Empty;
-                return;
+                return result;
             }
 
             foreach (var table in summary.Tables.OrderByDescending(table => table.TotalReads))
             {
-                Tables.Add(table);
+                result.Tables.Add(table);
             }
 
-            if (state.IsLoading)
-            {
-                StatusMessage = "Loading latest statistics output...";
-            }
-            else if (state.LastCaptureFailed)
-            {
-                StatusMessage = $"The latest execution did not expose statistics output before the retry window expired. Showing the most recent captured summary from {summary.CapturedAt:yyyy-MM-dd HH:mm:ss}.";
-            }
-            else
-            {
-                StatusMessage = string.Empty;
-            }
-
-            CapturedAtText = summary.CapturedAt.ToString("yyyy-MM-dd HH:mm:ss");
-            SourceText = BuildSourceText(summary);
-            TotalReadsText = summary.TotalReads.ToString("N0");
-            TotalElapsedText = FormatMilliseconds(summary.TotalElapsedMilliseconds);
-            TotalCpuText = FormatMilliseconds(summary.TotalCpuMilliseconds);
-            QueryTextPreview = summary.QueryText ?? string.Empty;
-        }
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        private void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            result.CapturedAtText = summary.CapturedAt.ToString("yyyy-MM-dd HH:mm:ss");
+            result.SourceText = BuildSourceText(summary);
+            result.TotalReadsText = summary.TotalReads.ToString("N0");
+            result.TotalElapsedText = FormatMilliseconds(summary.TotalElapsedMilliseconds);
+            result.TotalCpuText = FormatMilliseconds(summary.TotalCpuMilliseconds);
+            result.QueryTextPreview = summary.QueryText ?? string.Empty;
+            return result;
         }
 
         private static string BuildSourceText(StatisticsSummary summary)
@@ -219,5 +80,78 @@ namespace AxialSqlTools
 
             return milliseconds.Value.ToString("N0") + " ms";
         }
+    }
+
+    public class StatisticsSummaryViewModel : INotifyPropertyChanged
+    {
+        public ObservableCollection<StatisticsSummaryResultViewModel> Results { get; } = new ObservableCollection<StatisticsSummaryResultViewModel>();
+
+        private bool _isLoading;
+        public bool IsLoading
+        {
+            get => _isLoading;
+            set
+            {
+                if (_isLoading != value)
+                {
+                    _isLoading = value;
+                    OnPropertyChanged(nameof(IsLoading));
+                }
+            }
+        }
+
+        private string _statusMessage;
+        public string StatusMessage
+        {
+            get => _statusMessage;
+            set
+            {
+                if (_statusMessage != value)
+                {
+                    _statusMessage = value;
+                    OnPropertyChanged(nameof(StatusMessage));
+                }
+            }
+        }
+
+        private bool _showStatus;
+        public bool ShowStatus
+        {
+            get => _showStatus;
+            set
+            {
+                if (_showStatus != value)
+                {
+                    _showStatus = value;
+                    OnPropertyChanged(nameof(ShowStatus));
+                }
+            }
+        }
+
+        public StatisticsSummaryViewModel()
+        {
+            RefreshFromStore();
+        }
+
+        public void RefreshFromStore()
+        {
+            var state = StatisticsSummaryStore.GetState();
+            IsLoading = state.IsLoading;
+            ShowStatus = state.IsLoading;
+            StatusMessage = state.IsLoading ? "Loading latest statistics output..." : string.Empty;
+
+            var summaries = state.Summaries ?? Array.Empty<StatisticsSummary>();
+            Results.Clear();
+            Results.Add(StatisticsSummaryResultViewModel.Create("Latest result", summaries.ElementAtOrDefault(0), showDivider: false));
+            Results.Add(StatisticsSummaryResultViewModel.Create("Previous result", summaries.ElementAtOrDefault(1), showDivider: true));
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
     }
 }

--- a/AxialSqlTools/StatisticsSummary/StatisticsSummaryViewModel.cs
+++ b/AxialSqlTools/StatisticsSummary/StatisticsSummaryViewModel.cs
@@ -17,8 +17,10 @@ namespace AxialSqlTools
         public string TotalCpuText { get; set; }
         public string QueryTextPreview { get; set; }
         public bool HasTableData => Tables.Count > 0;
+        public string TableStatusMessage { get; set; }
+        public bool ShowTableStatus => !string.IsNullOrWhiteSpace(TableStatusMessage);
 
-        public static StatisticsSummaryResultViewModel Create(string title, StatisticsSummary summary, bool showDivider)
+        internal static StatisticsSummaryResultViewModel Create(string title, StatisticsSummaryStoreResult storeResult, bool showDivider)
         {
             var result = new StatisticsSummaryResultViewModel
             {
@@ -26,14 +28,30 @@ namespace AxialSqlTools
                 ShowDivider = showDivider,
                 CapturedAtText = "-",
                 SourceText = "-",
-                TotalReadsText = "0",
+                TotalReadsText = "-",
                 TotalElapsedText = "-",
                 TotalCpuText = "-",
                 QueryTextPreview = string.Empty,
             };
 
+            if (storeResult == null)
+            {
+                result.TableStatusMessage = title == "Latest result"
+                    ? "Execute a query to see statistics summary"
+                    : "No previous result";
+                return result;
+            }
+
+            if (storeResult.Status != StatisticsSummaryCaptureStatus.Success)
+            {
+                result.TableStatusMessage = BuildStatusMessage(storeResult.Status, title);
+                return result;
+            }
+
+            var summary = storeResult.Summary;
             if (summary == null || !summary.HasData)
             {
+                result.TableStatusMessage = "Failed to retrieve data";
                 return result;
             }
 
@@ -48,7 +66,31 @@ namespace AxialSqlTools
             result.TotalElapsedText = FormatMilliseconds(summary.TotalElapsedMilliseconds);
             result.TotalCpuText = FormatMilliseconds(summary.TotalCpuMilliseconds);
             result.QueryTextPreview = summary.QueryText ?? string.Empty;
+
+            if (!result.HasTableData)
+            {
+                result.TotalReadsText = "-";
+                result.TableStatusMessage = "SET STATISTICS IO ON to see read summary";
+            }
+
             return result;
+        }
+
+        private static string BuildStatusMessage(StatisticsSummaryCaptureStatus status, string title)
+        {
+            switch (status)
+            {
+                case StatisticsSummaryCaptureStatus.Loading:
+                    return "Loading latest statistics output...";
+                case StatisticsSummaryCaptureStatus.StatisticsDisabled:
+                    return "STATISTICS IO / TIME not turned on";
+                case StatisticsSummaryCaptureStatus.Failed:
+                    return "Failed to retrieve data";
+                default:
+                    return title == "Latest result"
+                        ? "Execute a query to see statistics summary"
+                        : "No previous result";
+            }
         }
 
         private static string BuildSourceText(StatisticsSummary summary)
@@ -140,10 +182,10 @@ namespace AxialSqlTools
             ShowStatus = state.IsLoading;
             StatusMessage = state.IsLoading ? "Loading latest statistics output..." : string.Empty;
 
-            var summaries = state.Summaries ?? Array.Empty<StatisticsSummary>();
+            var results = state.Results ?? Array.Empty<StatisticsSummaryStoreResult>();
             Results.Clear();
-            Results.Add(StatisticsSummaryResultViewModel.Create("Latest result", summaries.ElementAtOrDefault(0), showDivider: false));
-            Results.Add(StatisticsSummaryResultViewModel.Create("Previous result", summaries.ElementAtOrDefault(1), showDivider: true));
+            Results.Add(StatisticsSummaryResultViewModel.Create("Latest result", results.ElementAtOrDefault(0), showDivider: false));
+            Results.Add(StatisticsSummaryResultViewModel.Create("Previous result", results.ElementAtOrDefault(1), showDivider: true));
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/AxialSqlTools/StatisticsSummary/StatisticsSummaryWindowControl.xaml
+++ b/AxialSqlTools/StatisticsSummary/StatisticsSummaryWindowControl.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:primitives="clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework"
              mc:Ignorable="d"
              d:DesignHeight="700"
              d:DesignWidth="900"
@@ -53,12 +54,12 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
-                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <Grid Grid.Row="0" Margin="0,0,0,8">
+            <Grid Grid.Row="0"
+                  Margin="0,0,0,8"
+                  Visibility="{Binding ShowStatus, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
@@ -84,91 +85,164 @@
                          IsIndeterminate="True"
                          Visibility="{Binding IsLoading, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
-            <Grid Grid.Row="2" Margin="0,0,0,8">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
+            <ItemsControl Grid.Row="2" ItemsSource="{Binding Results}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <primitives:UniformGrid Rows="2" Columns="1" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
 
-                <Border Grid.Column="0" Margin="0,0,8,0" Padding="10" BorderBrush="{DynamicResource AxialThemeBorderBrush}" BorderThickness="1">
-                    <StackPanel>
-                        <TextBlock FontWeight="Bold" Text="Elapsed time" />
-                        <TextBlock Margin="0,6,0,0" FontSize="18" Text="{Binding TotalElapsedText}" />
-                    </StackPanel>
-                </Border>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border Margin="0,0,0,8"
+                                Padding="0"
+                                BorderBrush="{DynamicResource AxialThemeBorderBrush}">
+                            <Border.Style>
+                                <Style TargetType="{x:Type Border}">
+                                    <Setter Property="BorderThickness" Value="0" />
+                                    <Setter Property="Padding" Value="0" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding ShowDivider}" Value="True">
+                                            <Setter Property="BorderThickness" Value="0,1,0,0" />
+                                            <Setter Property="Padding" Value="0,10,0,0" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Border.Style>
 
-                <Border Grid.Column="1" Margin="0,0,8,0" Padding="10" BorderBrush="{DynamicResource AxialThemeBorderBrush}" BorderThickness="1">
-                    <StackPanel>
-                        <TextBlock FontWeight="Bold" Text="CPU time" />
-                        <TextBlock Margin="0,6,0,0" FontSize="18" Text="{Binding TotalCpuText}" />
-                    </StackPanel>
-                </Border>
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="*" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
 
-                <Border Grid.Column="2" Padding="10" BorderBrush="{DynamicResource AxialThemeBorderBrush}" BorderThickness="1">
-                    <StackPanel>
-                        <TextBlock FontWeight="Bold" Text="Total logical reads" />
-                        <TextBlock Margin="0,6,0,0" FontSize="18" Text="{Binding TotalReadsText}" />
-                    </StackPanel>
-                </Border>
-            </Grid>
+                                <Grid Grid.Row="0" Margin="0,0,0,6">
+                                <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
 
-            <DataGrid Grid.Row="3"
-                      Margin="0,0,0,8"
-                      IsReadOnly="True"
-                      AutoGenerateColumns="False"
-                      ItemsSource="{Binding Tables}"
-                      Style="{DynamicResource AxialThemedDataGridStyle}"
-                      ColumnHeaderStyle="{DynamicResource AxialThemedDataGridColumnHeaderStyle}"
-                      CellStyle="{DynamicResource AxialThemedDataGridCellStyle}"
-                      RowStyle="{DynamicResource AxialThemedDataGridRowStyle}">
-                <DataGrid.Columns>
-                    <DataGridTextColumn Header="Table" Binding="{Binding TableName}" Width="*" />
-                    <DataGridTextColumn Header="Scans" Binding="{Binding ScanCount, StringFormat={}{0:N0}}" Width="50" />
-                    <DataGridTextColumn Header="Logical reads"
-                                        Binding="{Binding TotalReads, StringFormat={}{0:N0}}"
-                                        Width="110"
-                                        HeaderStyle="{StaticResource StatisticsReadsHeaderStyle}"
-                                        ElementStyle="{StaticResource StatisticsReadsTextStyle}" />
-                </DataGrid.Columns>
-            </DataGrid>
+                                    <TextBlock Grid.Column="0"
+                                               VerticalAlignment="Center"
+                                               FontWeight="Bold"
+                                               FontSize="14"
+                                               Text="{Binding Title}" />
 
-            <Grid Grid.Row="4">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="180" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
+                                    <Button Grid.Column="1"
+                                            Margin="8,0,0,0"
+                                            Padding="10,3"
+                                            VerticalAlignment="Center"
+                                            Content="Copy as"
+                                            IsEnabled="{Binding HasTableData}"
+                                            Click="CopyAsButton_Click">
+                                        <Button.ContextMenu>
+                                            <ContextMenu>
+                                                <MenuItem Header="CSV"
+                                                          Click="CopyAsCsvMenuItem_Click"
+                                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                                <MenuItem Header="Markdown"
+                                                          Click="CopyAsMarkdownMenuItem_Click"
+                                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                                <MenuItem Header="JSON"
+                                                          Click="CopyAsJsonMenuItem_Click"
+                                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                            </ContextMenu>
+                                        </Button.ContextMenu>
+                                    </Button>
+                                </Grid>
 
-                <TextBlock Grid.Row="0" Grid.Column="0" FontWeight="Bold" Text="Captured at" />
-                <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding CapturedAtText}" />
+                                <Grid Grid.Row="1" Margin="0,0,0,8">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
 
-                <TextBlock Grid.Row="1" Grid.Column="0" Margin="0,4,0,0" FontWeight="Bold" Text="Source" />
-                <TextBlock Grid.Row="1" Grid.Column="1" Margin="0,4,0,0" Text="{Binding SourceText}" />
+                                    <Border Grid.Column="0" Margin="0,0,8,0" Padding="8" BorderBrush="{DynamicResource AxialThemeBorderBrush}" BorderThickness="1">
+                                        <StackPanel>
+                                            <TextBlock FontWeight="Bold" Text="Elapsed time" />
+                                            <TextBlock Margin="0,4,0,0" FontSize="16" Text="{Binding TotalElapsedText}" />
+                                        </StackPanel>
+                                    </Border>
 
-                <Expander Grid.Row="2"
-                          Grid.Column="0"
-                          Grid.ColumnSpan="2"
-                          Margin="0,8,0,0"
-                          Header="Source query"
-                          IsExpanded="False">
-                    <TextBox Margin="0,8,0,0"
-                             Height="160"
-                             Text="{Binding QueryTextPreview}"
-                             IsReadOnly="True"
-                             TextWrapping="NoWrap"
-                             AcceptsReturn="True"
-                             AcceptsTab="True"
-                             HorizontalScrollBarVisibility="Auto"
-                             VerticalScrollBarVisibility="Auto"
-                             FontFamily="Consolas"
-                             FontSize="12" />
-                </Expander>
-            </Grid>
+                                    <Border Grid.Column="1" Margin="0,0,8,0" Padding="8" BorderBrush="{DynamicResource AxialThemeBorderBrush}" BorderThickness="1">
+                                        <StackPanel>
+                                            <TextBlock FontWeight="Bold" Text="CPU time" />
+                                            <TextBlock Margin="0,4,0,0" FontSize="16" Text="{Binding TotalCpuText}" />
+                                        </StackPanel>
+                                    </Border>
+
+                                    <Border Grid.Column="2" Padding="8" BorderBrush="{DynamicResource AxialThemeBorderBrush}" BorderThickness="1">
+                                        <StackPanel>
+                                            <TextBlock FontWeight="Bold" Text="Total logical reads" />
+                                            <TextBlock Margin="0,4,0,0" FontSize="16" Text="{Binding TotalReadsText}" />
+                                        </StackPanel>
+                                    </Border>
+                                </Grid>
+
+                                <DataGrid Grid.Row="2"
+                                          Margin="0,0,0,8"
+                                          IsReadOnly="True"
+                                          AutoGenerateColumns="False"
+                                          ItemsSource="{Binding Tables}"
+                                          Style="{DynamicResource AxialThemedDataGridStyle}"
+                                          ColumnHeaderStyle="{DynamicResource AxialThemedDataGridColumnHeaderStyle}"
+                                          CellStyle="{DynamicResource AxialThemedDataGridCellStyle}"
+                                          RowStyle="{DynamicResource AxialThemedDataGridRowStyle}">
+                                    <DataGrid.Columns>
+                                        <DataGridTextColumn Header="Table" Binding="{Binding TableName}" Width="*" />
+                                        <DataGridTextColumn Header="Scans" Binding="{Binding ScanCount, StringFormat={}{0:N0}}" Width="50" />
+                                        <DataGridTextColumn Header="Logical reads"
+                                                            Binding="{Binding TotalReads, StringFormat={}{0:N0}}"
+                                                            Width="110"
+                                                            HeaderStyle="{StaticResource StatisticsReadsHeaderStyle}"
+                                                            ElementStyle="{StaticResource StatisticsReadsTextStyle}" />
+                                    </DataGrid.Columns>
+                                </DataGrid>
+
+                                <Grid Grid.Row="3">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="90" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+
+                                    <TextBlock Grid.Row="0" Grid.Column="0" FontWeight="Bold" Text="Captured at" />
+                                    <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding CapturedAtText}" />
+
+                                    <TextBlock Grid.Row="1" Grid.Column="0" Margin="0,4,0,0" FontWeight="Bold" Text="Source" />
+                                    <TextBlock Grid.Row="1" Grid.Column="1" Margin="0,4,0,0" Text="{Binding SourceText}" />
+
+                                    <Expander Grid.Row="2"
+                                              Grid.Column="0"
+                                              Grid.ColumnSpan="2"
+                                              Margin="0,8,0,0"
+                                              Header="Source query"
+                                              IsExpanded="False">
+                                        <TextBox Margin="0,8,0,0"
+                                                 Height="96"
+                                                 Text="{Binding QueryTextPreview}"
+                                                 IsReadOnly="True"
+                                                 TextWrapping="NoWrap"
+                                                 AcceptsReturn="True"
+                                                 AcceptsTab="True"
+                                                 HorizontalScrollBarVisibility="Auto"
+                                                 VerticalScrollBarVisibility="Auto"
+                                                 FontFamily="Consolas"
+                                                 FontSize="12" />
+                                    </Expander>
+                                </Grid>
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
         </Grid>
     </DockPanel>
 </UserControl>

--- a/AxialSqlTools/StatisticsSummary/StatisticsSummaryWindowControl.xaml
+++ b/AxialSqlTools/StatisticsSummary/StatisticsSummaryWindowControl.xaml
@@ -94,15 +94,15 @@
 
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Border Margin="0,0,0,8"
-                                Padding="0"
-                                BorderBrush="{DynamicResource AxialThemeBorderBrush}">
+                        <Border BorderBrush="{DynamicResource AxialThemeBorderBrush}">
                             <Border.Style>
                                 <Style TargetType="{x:Type Border}">
                                     <Setter Property="BorderThickness" Value="0" />
+                                    <Setter Property="Margin" Value="0,0,0,8" />
                                     <Setter Property="Padding" Value="0" />
                                     <Style.Triggers>
                                         <DataTrigger Binding="{Binding ShowDivider}" Value="True">
+                                            <Setter Property="Margin" Value="0,6,0,8" />
                                             <Setter Property="BorderThickness" Value="0,1,0,0" />
                                             <Setter Property="Padding" Value="0,10,0,0" />
                                         </DataTrigger>
@@ -182,25 +182,46 @@
                                     </Border>
                                 </Grid>
 
-                                <DataGrid Grid.Row="2"
-                                          Margin="0,0,0,8"
-                                          IsReadOnly="True"
-                                          AutoGenerateColumns="False"
-                                          ItemsSource="{Binding Tables}"
-                                          Style="{DynamicResource AxialThemedDataGridStyle}"
-                                          ColumnHeaderStyle="{DynamicResource AxialThemedDataGridColumnHeaderStyle}"
-                                          CellStyle="{DynamicResource AxialThemedDataGridCellStyle}"
-                                          RowStyle="{DynamicResource AxialThemedDataGridRowStyle}">
-                                    <DataGrid.Columns>
-                                        <DataGridTextColumn Header="Table" Binding="{Binding TableName}" Width="*" />
-                                        <DataGridTextColumn Header="Scans" Binding="{Binding ScanCount, StringFormat={}{0:N0}}" Width="50" />
-                                        <DataGridTextColumn Header="Logical reads"
-                                                            Binding="{Binding TotalReads, StringFormat={}{0:N0}}"
-                                                            Width="110"
-                                                            HeaderStyle="{StaticResource StatisticsReadsHeaderStyle}"
-                                                            ElementStyle="{StaticResource StatisticsReadsTextStyle}" />
-                                    </DataGrid.Columns>
-                                </DataGrid>
+                                <Grid Grid.Row="2" Margin="0,0,0,8" MinHeight="120">
+                                    <DataGrid IsReadOnly="True"
+                                              AutoGenerateColumns="False"
+                                              ItemsSource="{Binding Tables}"
+                                              ColumnHeaderStyle="{DynamicResource AxialThemedDataGridColumnHeaderStyle}"
+                                              CellStyle="{DynamicResource AxialThemedDataGridCellStyle}"
+                                              RowStyle="{DynamicResource AxialThemedDataGridRowStyle}">
+                                        <DataGrid.Style>
+                                            <Style TargetType="{x:Type DataGrid}" BasedOn="{StaticResource AxialThemedDataGridStyle}">
+                                                <Setter Property="Visibility" Value="Visible" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding HasTableData}" Value="False">
+                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </DataGrid.Style>
+                                        <DataGrid.Columns>
+                                            <DataGridTextColumn Header="Table" Binding="{Binding TableName}" Width="*" />
+                                            <DataGridTextColumn Header="Scans" Binding="{Binding ScanCount, StringFormat={}{0:N0}}" Width="50" />
+                                            <DataGridTextColumn Header="Logical reads"
+                                                                Binding="{Binding TotalReads, StringFormat={}{0:N0}}"
+                                                                Width="110"
+                                                                HeaderStyle="{StaticResource StatisticsReadsHeaderStyle}"
+                                                                ElementStyle="{StaticResource StatisticsReadsTextStyle}" />
+                                        </DataGrid.Columns>
+                                    </DataGrid>
+
+                                    <Border BorderBrush="{DynamicResource AxialThemeBorderBrush}"
+                                            BorderThickness="1"
+                                            Visibility="{Binding ShowTableStatus, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                        <TextBlock HorizontalAlignment="Center"
+                                                   VerticalAlignment="Center"
+                                                   Margin="16"
+                                                   TextAlignment="Center"
+                                                   TextWrapping="Wrap"
+                                                   FontSize="14"
+                                                   Text="{Binding TableStatusMessage}" />
+                                    </Border>
+                                </Grid>
 
                                 <Grid Grid.Row="3">
                                     <Grid.ColumnDefinitions>

--- a/AxialSqlTools/StatisticsSummary/StatisticsSummaryWindowControl.xaml.cs
+++ b/AxialSqlTools/StatisticsSummary/StatisticsSummaryWindowControl.xaml.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Navigation;
 using Microsoft.VisualStudio.Shell;
+using Newtonsoft.Json;
 
 namespace AxialSqlTools
 {
@@ -82,6 +87,124 @@ namespace AxialSqlTools
         private void CancelLoading_Click(object sender, System.Windows.RoutedEventArgs e)
         {
             AxialSqlToolsPackage.CancelStatisticsCapture();
+        }
+
+        private void CopyAsButton_Click(object sender, RoutedEventArgs e)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (!(sender is Button button) || !(button.ContextMenu is ContextMenu contextMenu))
+            {
+                return;
+            }
+
+            contextMenu.PlacementTarget = button;
+            contextMenu.Placement = PlacementMode.Bottom;
+            contextMenu.IsOpen = true;
+        }
+
+        private void CopyAsCsvMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            CopyResultTableToClipboard(sender, BuildCsvText);
+        }
+
+        private void CopyAsMarkdownMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            CopyResultTableToClipboard(sender, BuildMarkdownText);
+        }
+
+        private void CopyAsJsonMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            CopyResultTableToClipboard(sender, BuildJsonText);
+        }
+
+        private static void CopyResultTableToClipboard(object sender, Func<StatisticsSummaryResultViewModel, string> formatter)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var result = GetResultFromMenuItem(sender);
+            if (result == null || !result.HasTableData)
+            {
+                return;
+            }
+
+            CopyTextToClipboard(formatter(result));
+        }
+
+        private static StatisticsSummaryResultViewModel GetResultFromMenuItem(object sender)
+        {
+            return (sender as MenuItem)?.CommandParameter as StatisticsSummaryResultViewModel;
+        }
+
+        private static string BuildCsvText(StatisticsSummaryResultViewModel result)
+        {
+            var lines = new List<string>
+            {
+                string.Join(",", new[] { "Table", "Scans", "Logical reads" })
+            };
+
+            lines.AddRange(result.Tables.Select(table => string.Join(",",
+                EscapeCsv(table.TableName),
+                EscapeCsv(table.ScanCount.ToString()),
+                EscapeCsv(table.TotalReads.ToString()))));
+
+            return string.Join(Environment.NewLine, lines);
+        }
+
+        private static string BuildMarkdownText(StatisticsSummaryResultViewModel result)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("| Table | Scans | Logical reads |");
+            sb.AppendLine("| --- | ---: | ---: |");
+
+            foreach (var table in result.Tables)
+            {
+                sb.Append("| ");
+                sb.Append(EscapeMarkdown(table.TableName));
+                sb.Append(" | ");
+                sb.Append(table.ScanCount);
+                sb.Append(" | ");
+                sb.Append(table.TotalReads);
+                sb.AppendLine(" |");
+            }
+
+            return sb.ToString().TrimEnd();
+        }
+
+        private static string BuildJsonText(StatisticsSummaryResultViewModel result)
+        {
+            var rows = result.Tables.Select(table => new Dictionary<string, object>
+            {
+                { "Table", table.TableName ?? string.Empty },
+                { "Scans", table.ScanCount },
+                { "Logical reads", table.TotalReads },
+            });
+
+            return JsonConvert.SerializeObject(rows, Formatting.Indented);
+        }
+
+        private static string EscapeCsv(string value)
+        {
+            value = value ?? string.Empty;
+            return "\"" + value.Replace("\"", "\"\"") + "\"";
+        }
+
+        private static string EscapeMarkdown(string value)
+        {
+            return (value ?? string.Empty).Replace("|", "\\|");
+        }
+
+        private static void CopyTextToClipboard(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return;
+            }
+
+            Clipboard.SetDataObject(text);
         }
     }
 }


### PR DESCRIPTION
## Summary

This improves the Statistics Summary workflow in two areas: capture reliability and usability.

On the capture side, we no longer rely on a long retry window to wait for SSMS to expose statistics output. Instead, we explicitly focus the Messages tab, flush pending output, and read the statistics text from the place SSMS exposes it most reliably. That makes capture much more deterministic and lets us cut the retry loop down substantially.

On the UI side, the summary window now keeps and displays the two most recent captured results so it is easier to compare consecutive query runs without losing the previous snapshot.

## Why

Previously, the feature used a high retry count because it looked like SSMS was slow to surface `SET STATISTICS IO/TIME` output. In practice, the issue was not raw delay so much as where we were reading from. Once we switch focus to the Messages tab, the output becomes reliably available, so the old retry behavior was adding unnecessary wait time.

We also should not poll for statistics at all when the current session does not have `STATISTICS IO` or `STATISTICS TIME` enabled. Doing so creates avoidable retries and misleading “failed to capture” behavior for executions that were never going to produce statistics output.

Finally, showing only one summary made before/after query tuning harder than it needed to be. Keeping the latest two results makes quick comparisons much easier.

## Changes

- Update statistics capture to read from the SSMS Messages tab instead of relying on repeated polling from the prior context.
- Restore the previously selected tab after capture so the read is more reliable without permanently changing the user’s view.
- Reduce the retry window from `24 x 300ms` to `3 x 150ms` because focusing the Messages tab makes capture reliable enough that the old wait strategy is no longer necessary.
- Check the current session options before polling by inspecting `DBCC USEROPTIONS`; only attempt statistics capture when `statistics io` or `statistics time` is enabled.
- Mark the capture as unavailable immediately when statistics output is not enabled in the current context instead of waiting through retries.
- Refactor the summary view model/UI to render each result independently, including its own totals, table breakdown, capture metadata, and source query preview.
- Add per-result copy/export actions for the table summary in `CSV`, `Markdown`, and `JSON`.

## Impact

- Faster statistics capture after execution.
- Fewer false “timeout” style failures when statistics output is available.
- No wasted polling when `SET STATISTICS IO/TIME` is off.
- Easier comparison of two query executions during tuning.
- Easier sharing/export of table-level read summaries.

## Testing

- Run queries with `SET STATISTICS IO ON` and/or `SET STATISTICS TIME ON` and verify summaries appear quickly.
- Run two queries back to back and verify both the latest and previous summaries are shown separately.
- Run queries without statistics enabled and verify the window does not sit through a long retry loop.
- Verify `Copy as` output for CSV, Markdown, and JSON.