### PR TITLE
Snippets - keep current indent 

### DIFF
--- a/AxialSqlTools/Modules/KeypressCommandFilter.cs
+++ b/AxialSqlTools/Modules/KeypressCommandFilter.cs
@@ -105,6 +105,12 @@ namespace AxialSqlTools
             string newText = result.ProcessedText;
             int cursorOffset = result.CursorOffset;
 
+            var indent = wordStart;
+            if (indent > 0)
+            {
+                newText = newText.Replace(Environment.NewLine, Environment.NewLine + new string(' ', indent));
+            }
+
             IntPtr pNewText = Marshal.StringToHGlobalUni(newText);
             try
             {


### PR DESCRIPTION
If the snippet body contains multiple lines, each line starts at position 0. This change preserves the indent of new lines according to the current cursor position.

Example:
```
BEGIN
  ssf
END
``` 
Current behavior:
```
BEGIN
  SELECT *
FROM
END
``` 

Desired behavior:
```
BEGIN
  SELECT *
  FROM
END
``` 