### PR TITLE
Add configurable T-SQL parser version and General settings tab

### DIFF
--- a/AxialSqlTools/AxialSqlTools.csproj
+++ b/AxialSqlTools/AxialSqlTools.csproj
@@ -157,6 +157,7 @@
     <Compile Include="Modules\SettingsManager.cs" />
     <Compile Include="Modules\SQLBuilds.cs" />
     <Compile Include="Modules\TsqlFormatter.cs" />
+    <Compile Include="Modules\TSqlParserFactory.cs" />
     <Compile Include="Modules\WindowsCredentialHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AxialSqlToolsPackage.cs" />

--- a/AxialSqlTools/Commands/SelectCurrentStatementCommand.cs
+++ b/AxialSqlTools/Commands/SelectCurrentStatementCommand.cs
@@ -71,7 +71,7 @@ namespace AxialSqlTools
                 if (string.IsNullOrEmpty(fullText))
                     return;
 
-                // Try parsing with TSql170Parser
+                // Try parsing with the configured T-SQL parser
                 if (TrySelectWithParser(fullText, cursorLine, cursorColumn, selection))
                     return;
 
@@ -94,7 +94,7 @@ namespace AxialSqlTools
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            TSql170Parser sqlParser = new TSql170Parser(false);
+            TSqlParser sqlParser = TSqlParserFactory.Create(false);
             IList<ParseError> parseErrors;
             TSqlFragment fragment = sqlParser.Parse(new StringReader(fullText), out parseErrors);
 

--- a/AxialSqlTools/Commands/ToggleBlockCommentCommand.cs
+++ b/AxialSqlTools/Commands/ToggleBlockCommentCommand.cs
@@ -155,7 +155,7 @@ namespace AxialSqlTools
             openPosition = default(TextPosition);
             closePosition = default(TextPosition);
 
-            var parser = new TSql170Parser(initialQuotedIdentifiers: true);
+            var parser = TSqlParserFactory.Create(initialQuotedIdentifiers: true);
             IList<ParseError> errors;
             IList<TSqlParserToken> tokens = parser.GetTokenStream(new StringReader(text), out errors);
             foreach (TSqlParserToken token in tokens)

--- a/AxialSqlTools/Modules/ScriptObjectDefinition.cs
+++ b/AxialSqlTools/Modules/ScriptObjectDefinition.cs
@@ -244,14 +244,14 @@ namespace AxialSqlTools
                 // additional format to make it pretty
                 if (selectedObject.TypeDesc == "USER_TABLE")
                 {
-                    TSql170Parser sqlParser = new TSql170Parser(false);
+                    TSqlParser sqlParser = TSqlParserFactory.Create(false);
                     IList<ParseError> parseErrors = new List<ParseError>();
                     TSqlFragment result = sqlParser.Parse(new StringReader(fullScriptResult), out parseErrors);
 
                     // leave it as is if for some reason we can't format it
                     if (parseErrors.Count == 0)
                     {
-                        Sql170ScriptGenerator gen = new Sql170ScriptGenerator();
+                        SqlScriptGenerator gen = TSqlParserFactory.CreateScriptGenerator();
                         gen.Options.AlignClauseBodies = false;
                         gen.Options.IncludeSemicolons = false;
                         gen.GenerateScript(result, out fullScriptResult);

--- a/AxialSqlTools/Modules/SettingsManager.cs
+++ b/AxialSqlTools/Modules/SettingsManager.cs
@@ -252,6 +252,50 @@ ORDER BY sd.[name];
             public bool EnableSsl;
         }
 
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public enum TSqlParserVersion
+        {
+            Sql80,
+            Sql90,
+            Sql100,
+            Sql110,
+            Sql120,
+            Sql130,
+            Sql140,
+            Sql150,
+            Sql160,
+            Sql170
+        }
+
+        public static string GetTSqlParserVersionDisplayName(TSqlParserVersion version)
+        {
+            switch (version)
+            {
+                case TSqlParserVersion.Sql80:
+                    return "SQL Server 2000 (8.0)";
+                case TSqlParserVersion.Sql90:
+                    return "SQL Server 2005 (9.0)";
+                case TSqlParserVersion.Sql100:
+                    return "SQL Server 2008 (10.0)";
+                case TSqlParserVersion.Sql110:
+                    return "SQL Server 2012 (11.0)";
+                case TSqlParserVersion.Sql120:
+                    return "SQL Server 2014 (12.0)";
+                case TSqlParserVersion.Sql130:
+                    return "SQL Server 2016 (13.0)";
+                case TSqlParserVersion.Sql140:
+                    return "SQL Server 2017 (14.0)";
+                case TSqlParserVersion.Sql150:
+                    return "SQL Server 2019 (15.0)";
+                case TSqlParserVersion.Sql160:
+                    return "SQL Server 2022 (16.0)";
+                case TSqlParserVersion.Sql170:
+                default:
+                    return "SQL Server 2025 (17.0)";
+            }
+        }
+
         public enum SnippetReplaceKey
         {
             Enter,
@@ -548,6 +592,23 @@ ORDER BY sd.[name];
 
             return true;
 
+        }
+
+
+        public static TSqlParserVersion GetTSqlParserVersion()
+        {
+            string value = GetRegisterValue("TSqlParserVersion");
+            if (Enum.TryParse(value, out TSqlParserVersion version))
+            {
+                return version;
+            }
+
+            return TSqlParserVersion.Sql170;
+        }
+
+        public static bool SaveTSqlParserVersion(TSqlParserVersion version)
+        {
+            return SaveRegisterValue("TSqlParserVersion", version.ToString());
         }
 
         public static string GetTemplatesFolder()

--- a/AxialSqlTools/Modules/TSqlParserFactory.cs
+++ b/AxialSqlTools/Modules/TSqlParserFactory.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.SqlServer.TransactSql.ScriptDom;
+
+namespace AxialSqlTools
+{
+    public static class TSqlParserFactory
+    {
+        public static TSqlParser Create(bool initialQuotedIdentifiers)
+        {
+            return Create(SettingsManager.GetTSqlParserVersion(), initialQuotedIdentifiers);
+        }
+
+        public static TSqlParser Create(SettingsManager.TSqlParserVersion version, bool initialQuotedIdentifiers)
+        {
+            switch (version)
+            {
+                case SettingsManager.TSqlParserVersion.Sql80:
+                    return new TSql80Parser(initialQuotedIdentifiers);
+                case SettingsManager.TSqlParserVersion.Sql90:
+                    return new TSql90Parser(initialQuotedIdentifiers);
+                case SettingsManager.TSqlParserVersion.Sql100:
+                    return new TSql100Parser(initialQuotedIdentifiers);
+                case SettingsManager.TSqlParserVersion.Sql110:
+                    return new TSql110Parser(initialQuotedIdentifiers);
+                case SettingsManager.TSqlParserVersion.Sql120:
+                    return new TSql120Parser(initialQuotedIdentifiers);
+                case SettingsManager.TSqlParserVersion.Sql130:
+                    return new TSql130Parser(initialQuotedIdentifiers);
+                case SettingsManager.TSqlParserVersion.Sql140:
+                    return new TSql140Parser(initialQuotedIdentifiers);
+                case SettingsManager.TSqlParserVersion.Sql150:
+                    return new TSql150Parser(initialQuotedIdentifiers);
+                case SettingsManager.TSqlParserVersion.Sql160:
+                    return new TSql160Parser(initialQuotedIdentifiers);
+                case SettingsManager.TSqlParserVersion.Sql170:
+                default:
+                    return new TSql170Parser(initialQuotedIdentifiers);
+            }
+        }
+
+        public static SqlScriptGenerator CreateScriptGenerator()
+        {
+            switch (SettingsManager.GetTSqlParserVersion())
+            {
+                case SettingsManager.TSqlParserVersion.Sql80:
+                    return new Sql80ScriptGenerator();
+                case SettingsManager.TSqlParserVersion.Sql90:
+                    return new Sql90ScriptGenerator();
+                case SettingsManager.TSqlParserVersion.Sql100:
+                    return new Sql100ScriptGenerator();
+                case SettingsManager.TSqlParserVersion.Sql110:
+                    return new Sql110ScriptGenerator();
+                case SettingsManager.TSqlParserVersion.Sql120:
+                    return new Sql120ScriptGenerator();
+                case SettingsManager.TSqlParserVersion.Sql130:
+                    return new Sql130ScriptGenerator();
+                case SettingsManager.TSqlParserVersion.Sql140:
+                    return new Sql140ScriptGenerator();
+                case SettingsManager.TSqlParserVersion.Sql150:
+                    return new Sql150ScriptGenerator();
+                case SettingsManager.TSqlParserVersion.Sql160:
+                    return new Sql160ScriptGenerator();
+                case SettingsManager.TSqlParserVersion.Sql170:
+                default:
+                    return new Sql170ScriptGenerator();
+            }
+        }
+    }
+}

--- a/AxialSqlTools/Modules/TsqlFormatter.cs
+++ b/AxialSqlTools/Modules/TsqlFormatter.cs
@@ -291,7 +291,7 @@ namespace AxialSqlTools
         {
             string resultCode = "";
 
-            TSql170Parser sqlParser = new TSql170Parser(false);
+            TSqlParser sqlParser = TSqlParserFactory.Create(false);
 
             IList<ParseError> parseErrors = new List<ParseError>();
             TSqlFragment result = sqlParser.Parse(new StringReader(oldCode), out parseErrors);
@@ -313,9 +313,8 @@ namespace AxialSqlTools
                 formatSettings = settingsOverride;
             }
 
-            Sql170ScriptGenerator gen = new Sql170ScriptGenerator();
+            SqlScriptGenerator gen = TSqlParserFactory.CreateScriptGenerator();
             gen.Options.AlignClauseBodies = false;
-            gen.Options.SqlVersion = SqlVersion.Sql170; //TODO - try to get from current connection
 
             if (formatSettings.preserveComments)
             {
@@ -342,7 +341,7 @@ namespace AxialSqlTools
 
         }
 
-        private static string ApplySpecialFormat(string oldCode, TSql170Parser sqlParser, SettingsManager.TSqlCodeFormatSettings formatSettings)
+        private static string ApplySpecialFormat(string oldCode, TSqlParser sqlParser, SettingsManager.TSqlCodeFormatSettings formatSettings)
         {
             IList<ParseError> parseErrors = new List<ParseError>();
 

--- a/AxialSqlTools/Modules/TsqlFormatterCommentInterleaver.cs
+++ b/AxialSqlTools/Modules/TsqlFormatterCommentInterleaver.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Microsoft.SqlServer.TransactSql.ScriptDom;
+using AxialSqlTools;
 
 public static class TsqlFormatterCommentInterleaver
 {
@@ -17,7 +18,7 @@ public static class TsqlFormatterCommentInterleaver
         if (generator == null) throw new ArgumentNullException(nameof(generator));
 
         if (parser is null)
-            parser = new TSql170Parser(initialQuotedIdentifiers: true);
+            parser = TSqlParserFactory.Create(initialQuotedIdentifiers: true);
 
         generator.GenerateScript(sqlFragment, out var formattedSql);
 

--- a/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
+++ b/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
@@ -105,6 +105,46 @@
                     BorderBrush="{DynamicResource AxialThemeBorderBrush}"
 					BorderThickness="1">
 
+
+            <TabItem Header="General">
+                <Grid Margin="10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="300"/>
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Margin="5">
+                        <TextBlock Text="SQL version" FontWeight="SemiBold"/>
+                        <TextBlock Text="Determines the version of the T-SQL language to use." Margin="0,2,0,0"/>
+                    </StackPanel>
+
+                    <ComboBox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                              x:Name="SqlVersion"
+                              DisplayMemberPath="DisplayName"
+                              SelectedValuePath="Version"
+                              Margin="5"
+                              Height="24"/>
+
+                    <Button Grid.Row="2" Grid.Column="1"
+                            x:Name="Button_SaveGeneralSettings"
+                            Click="Button_SaveGeneralSettings_Click"
+                            Margin="5"
+                            Width="80"
+                            Height="24"
+                            HorizontalAlignment="Right">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+                            <Path Width="12" Height="12" Data="{StaticResource SaveIconGeometry}" Style="{StaticResource AxialSaveIconPathStyle}" Margin="0,0,4,0"/>
+                            <TextBlock Text="Save" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Button>
+                </Grid>
+            </TabItem>
+
             <TabItem Header="Query Templates">
                 <Grid>
                     <Grid.RowDefinitions>

--- a/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml.cs
+++ b/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml.cs
@@ -13,6 +13,7 @@
     using System.Windows;
     using System.Windows.Controls;
     using System.Collections.ObjectModel;
+    using System.Linq;
     using System.Windows.Media;
     using System.Windows.Navigation;
     using Microsoft.VisualBasic;
@@ -58,6 +59,7 @@ as select 1;
 
             _connectionColorRules = new ObservableCollection<SettingsManager.ConnectionColorRule>();
             ConnectionColorRulesListView.ItemsSource = _connectionColorRules;
+            SqlVersion.ItemsSource = GetSqlVersionOptions();
 
             _themeController = new ToolWindowThemeController(this, ApplyThemeBrushResources);
 
@@ -132,6 +134,8 @@ as select 1;
         {
             try
             {
+
+                SqlVersion.SelectedValue = SettingsManager.GetTSqlParserVersion();
 
                 ScriptFolder.Text = SettingsManager.GetTemplatesFolder();
 
@@ -241,6 +245,30 @@ as select 1;
                 }
             }
 
+        }
+
+
+        private static object[] GetSqlVersionOptions()
+        {
+            return Enum.GetValues(typeof(SettingsManager.TSqlParserVersion))
+                .Cast<SettingsManager.TSqlParserVersion>()
+                .OrderByDescending(version => version)
+                .Select(version => new
+                {
+                    Version = version,
+                    DisplayName = SettingsManager.GetTSqlParserVersionDisplayName(version)
+                })
+                .ToArray();
+        }
+
+        private void Button_SaveGeneralSettings_Click(object sender, RoutedEventArgs e)
+        {
+            if (SqlVersion.SelectedValue is SettingsManager.TSqlParserVersion version)
+            {
+                SettingsManager.SaveTSqlParserVersion(version);
+            }
+
+            SavedMessage();
         }
 
         private void Button_SaveScriptFolder_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
### Motivation
- Introduce a first Settings page "General" to let users choose the T-SQL/SQL Server version for ScriptDom parsing and generation. 
- Ensure all places that instantiate `TSqlParser` or `Sql*ScriptGenerator` use the configured parser version instead of hard-coded `TSql170Parser`/`Sql170ScriptGenerator`.

### Description
- Add a new `General` tab to the settings UI with a `ComboBox` (`SqlVersion`) and `Save` button to select and persist the parser version. 
- Add `TSqlParserVersion` enum and helper methods `GetTSqlParserVersion()`, `SaveTSqlParserVersion()` and `GetTSqlParserVersionDisplayName()` in `SettingsManager` to store and present the option. 
- Add a central `TSqlParserFactory` that exposes `Create(bool initialQuotedIdentifiers)` and `CreateScriptGenerator()` to return the correct `TSqlParser` and `SqlScriptGenerator` for the configured version. 
- Replace local hard-coded usages of `TSql170Parser`/`Sql170ScriptGenerator` with calls to `TSqlParserFactory.Create(...)` and `TSqlParserFactory.CreateScriptGenerator()` in formatter, comment interleaver, object scripting, selection, and block-comment code paths, and add the new file to the project (`AxialSqlTools.csproj`).

### Testing
- Ran `git diff --check` which passed without errors. 
- Verified repository-wide replacements with `rg` searches to ensure parser/generator usages were switched to `TSqlParserFactory` and no remaining hard-coded `TSql170Parser`/`Sql170ScriptGenerator` instances remain in updated files. 
- Attempted to build with `msbuild` and `dotnet build` but both tools were not available in the environment so full compilation could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d1d8085e48333b7305f2c981022bf)