### PR TITLE
New take on sql formatter

### DIFF
--- a/AxialSqlTools/Commands/Dialogs/FormatOptionsDialog.xaml
+++ b/AxialSqlTools/Commands/Dialogs/FormatOptionsDialog.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Query Format Options" SizeToContent="WidthAndHeight"
         WindowStartupLocation="CenterOwner" ResizeMode="NoResize">
-    <DockPanel Margin="12" MinWidth="520">
+    <DockPanel Margin="12" MinWidth="620">
 
         <Grid DockPanel.Dock="Top" Margin="0,0,0,8">
             <Grid.ColumnDefinitions>
@@ -24,7 +24,7 @@
                         Click="UncheckAllOptions_Click"/>
             </StackPanel>
         </Grid>
-        <UniformGrid Columns="2" Margin="5" HorizontalAlignment="Left">
+        <UniformGrid DockPanel.Dock="Top" Columns="2" Margin="5" HorizontalAlignment="Left">
             <CheckBox x:Name="PreserveComments" Margin="5"
                  Content="Preserve comments"
                  Checked="formatSetting_Checked"
@@ -67,6 +67,38 @@
                 Unchecked="formatSetting_Unchecked"/>
             <CheckBox x:Name="BreakSprocDefinitionParametersPerLine" Margin="5"
                 Content="Break sproc definition parameters per line"
+                Checked="formatSetting_Checked"
+                Unchecked="formatSetting_Unchecked"/>
+            <CheckBox x:Name="LeadingCommas" Margin="5"
+                Content="Use leading commas"
+                Checked="formatSetting_Checked"
+                Unchecked="formatSetting_Unchecked"/>
+            <CheckBox x:Name="SemicolonBeforeCte" Margin="5"
+                Content="Put semicolon before CTE"
+                Checked="formatSetting_Checked"
+                Unchecked="formatSetting_Unchecked"/>
+            <CheckBox x:Name="BreakSelectElementsPerLine" Margin="5"
+                Content="Put SELECT fields on separate lines"
+                Checked="formatSetting_Checked"
+                Unchecked="formatSetting_Unchecked"/>
+            <CheckBox x:Name="UseAssignmentAliases" Margin="5"
+                Content="Use alias = expression for column aliases"
+                Checked="formatSetting_Checked"
+                Unchecked="formatSetting_Unchecked"/>
+            <CheckBox x:Name="OmitAsForTableAliases" Margin="5"
+                Content="Omit AS for table aliases"
+                Checked="formatSetting_Checked"
+                Unchecked="formatSetting_Unchecked"/>
+            <CheckBox x:Name="OmitAsInDeclare" Margin="5"
+                Content="Omit AS in DECLARE types"
+                Checked="formatSetting_Checked"
+                Unchecked="formatSetting_Unchecked"/>
+            <CheckBox x:Name="FormatTableDefinitionsMultiline" Margin="5"
+                Content="Put table variable columns on separate lines"
+                Checked="formatSetting_Checked"
+                Unchecked="formatSetting_Unchecked"/>
+            <CheckBox x:Name="PrefixUnicodeStrings" Margin="5"
+                Content="Prefix string literals with N"
                 Checked="formatSetting_Checked"
                 Unchecked="formatSetting_Unchecked"/>
         </UniformGrid>

--- a/AxialSqlTools/Commands/Dialogs/FormatOptionsDialog.xaml.cs
+++ b/AxialSqlTools/Commands/Dialogs/FormatOptionsDialog.xaml.cs
@@ -27,6 +27,14 @@ namespace AxialSqlTools
             UnindentBeginEndBlocks.IsChecked = Settings.unindentBeginEndBlocks;
             BreakVariableDefinitionsPerLine.IsChecked = Settings.breakVariableDefinitionsPerLine;
             BreakSprocDefinitionParametersPerLine.IsChecked = Settings.breakSprocDefinitionParametersPerLine;
+            LeadingCommas.IsChecked = Settings.leadingCommas;
+            SemicolonBeforeCte.IsChecked = Settings.semicolonBeforeCte;
+            BreakSelectElementsPerLine.IsChecked = Settings.breakSelectElementsPerLine;
+            UseAssignmentAliases.IsChecked = Settings.useAssignmentAliases;
+            OmitAsForTableAliases.IsChecked = Settings.omitAsForTableAliases;
+            OmitAsInDeclare.IsChecked = Settings.omitAsInDeclare;
+            FormatTableDefinitionsMultiline.IsChecked = Settings.formatTableDefinitionsMultiline;
+            PrefixUnicodeStrings.IsChecked = Settings.prefixUnicodeStrings;
         }
 
         private void formatSetting_Checked(object sender, RoutedEventArgs e)
@@ -51,6 +59,14 @@ namespace AxialSqlTools
             UnindentBeginEndBlocks.IsChecked = value;
             BreakVariableDefinitionsPerLine.IsChecked = value;
             BreakSprocDefinitionParametersPerLine.IsChecked = value;
+            LeadingCommas.IsChecked = value;
+            SemicolonBeforeCte.IsChecked = value;
+            BreakSelectElementsPerLine.IsChecked = value;
+            UseAssignmentAliases.IsChecked = value;
+            OmitAsForTableAliases.IsChecked = value;
+            OmitAsInDeclare.IsChecked = value;
+            FormatTableDefinitionsMultiline.IsChecked = value;
+            PrefixUnicodeStrings.IsChecked = value;
         }
 
         private void CheckAllOptions_Click(object sender, RoutedEventArgs e)
@@ -76,6 +92,15 @@ namespace AxialSqlTools
             Settings.unindentBeginEndBlocks = UnindentBeginEndBlocks.IsChecked == true;
             Settings.breakVariableDefinitionsPerLine = BreakVariableDefinitionsPerLine.IsChecked == true;
             Settings.breakSprocDefinitionParametersPerLine = BreakSprocDefinitionParametersPerLine.IsChecked == true;
+            Settings.leadingCommas = LeadingCommas.IsChecked == true;
+            Settings.semicolonBeforeCte = SemicolonBeforeCte.IsChecked == true;
+            Settings.breakSelectElementsPerLine = BreakSelectElementsPerLine.IsChecked == true;
+            Settings.useAssignmentAliases = UseAssignmentAliases.IsChecked == true;
+            Settings.omitAsForTableAliases = OmitAsForTableAliases.IsChecked == true;
+            Settings.omitAsInDeclare = OmitAsInDeclare.IsChecked == true;
+            Settings.formatTableDefinitionsMultiline = FormatTableDefinitionsMultiline.IsChecked == true;
+            Settings.prefixUnicodeStrings = PrefixUnicodeStrings.IsChecked == true;
+            Settings.removeSemicolonsFromDeclare = Settings.formatTableDefinitionsMultiline;
         }
 
         private void Ok_Click(object sender, RoutedEventArgs e)

--- a/AxialSqlTools/Modules/SettingsManager.cs
+++ b/AxialSqlTools/Modules/SettingsManager.cs
@@ -336,6 +336,16 @@ ORDER BY sd.[name];
             public bool breakVariableDefinitionsPerLine = false;
             public bool breakSprocDefinitionParametersPerLine = false;
             public bool breakSelectFieldsAfterTopAndUnindent = false;
+            public bool leadingCommas = false;
+            public bool semicolonBeforeCte = false;
+            public bool useFreehandFormatMode = false;
+            public bool breakSelectElementsPerLine = false;
+            public bool useAssignmentAliases = false;
+            public bool omitAsForTableAliases = false;
+            public bool omitAsInDeclare = false;
+            public bool formatTableDefinitionsMultiline = false;
+            public bool prefixUnicodeStrings = false;
+            public bool removeSemicolonsFromDeclare = false;
 
             public bool HasAnyFormattingEnabled()
             {
@@ -350,7 +360,16 @@ ORDER BY sd.[name];
                     || unindentBeginEndBlocks
                     || breakVariableDefinitionsPerLine
                     || breakSprocDefinitionParametersPerLine
-                    || breakSelectFieldsAfterTopAndUnindent;
+                    || breakSelectFieldsAfterTopAndUnindent
+                    || leadingCommas
+                    || semicolonBeforeCte
+                    || breakSelectElementsPerLine
+                    || useAssignmentAliases
+                    || omitAsForTableAliases
+                    || omitAsInDeclare
+                    || formatTableDefinitionsMultiline
+                    || prefixUnicodeStrings
+                    || removeSemicolonsFromDeclare;
             }
         }
 

--- a/AxialSqlTools/Modules/TsqlFormatter.cs
+++ b/AxialSqlTools/Modules/TsqlFormatter.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using static AxialSqlTools.AxialSqlToolsPackage;
 
 namespace AxialSqlTools
@@ -24,6 +25,15 @@ namespace AxialSqlTools
             public List<AlterProcedureStatement> SprocDefinitionsAlter = new List<AlterProcedureStatement>();
             public List<CreateOrAlterProcedureStatement> SprocDefinitionsCreateAlter = new List<CreateOrAlterProcedureStatement>();
             public List<QuerySpecification> SelectsWithTop = new List<QuerySpecification>();
+            public List<StatementWithCtesAndXmlNamespaces> StatementsWithCtes = new List<StatementWithCtesAndXmlNamespaces>();
+
+            private void TrackStatementWithCtes(StatementWithCtesAndXmlNamespaces node)
+            {
+                if (node.WithCtesAndXmlNamespaces?.CommonTableExpressions?.Count > 0)
+                {
+                    StatementsWithCtes.Add(node);
+                }
+            }
 
             public override void ExplicitVisit(QualifiedJoin node)
             {
@@ -194,6 +204,36 @@ namespace AxialSqlTools
                 DeclareStatements.Add(node);
             }
 
+            public override void ExplicitVisit(SelectStatement node)
+            {
+                base.ExplicitVisit(node);
+                TrackStatementWithCtes(node);
+            }
+
+            public override void ExplicitVisit(InsertStatement node)
+            {
+                base.ExplicitVisit(node);
+                TrackStatementWithCtes(node);
+            }
+
+            public override void ExplicitVisit(UpdateStatement node)
+            {
+                base.ExplicitVisit(node);
+                TrackStatementWithCtes(node);
+            }
+
+            public override void ExplicitVisit(DeleteStatement node)
+            {
+                base.ExplicitVisit(node);
+                TrackStatementWithCtes(node);
+            }
+
+            public override void ExplicitVisit(MergeStatement node)
+            {
+                base.ExplicitVisit(node);
+                TrackStatementWithCtes(node);
+            }
+
             public override void ExplicitVisit(QuerySpecification node)
             {
                 base.ExplicitVisit(node);
@@ -290,6 +330,16 @@ namespace AxialSqlTools
         public static string FormatCode(string oldCode, SettingsManager.TSqlCodeFormatSettings settingsOverride = null)
         {
             string resultCode = "";
+            var formatSettings = SettingsManager.GetTSqlCodeFormatSettings();
+            if (settingsOverride != null)
+            {
+                formatSettings = settingsOverride;
+            }
+
+            if (!HasTransformFormattingEnabled(formatSettings))
+            {
+                return oldCode;
+            }
 
             TSql170Parser sqlParser = new TSql170Parser(false);
 
@@ -307,14 +357,14 @@ namespace AxialSqlTools
                 throw new Exception($"TSqlParser unable to load selected T-SQL due to a syntax error:{Environment.NewLine}{errorStr}");
             }
 
-            var formatSettings = SettingsManager.GetTSqlCodeFormatSettings();
-            if (settingsOverride != null)
-            {
-                formatSettings = settingsOverride;
-            }
-
             Sql170ScriptGenerator gen = new Sql170ScriptGenerator();
             gen.Options.AlignClauseBodies = false;
+            gen.Options.AlignColumnDefinitionFields = false;
+            gen.Options.MultilineSelectElementsList = formatSettings.breakSelectElementsPerLine;
+            gen.Options.NewLineBeforeFromClause = formatSettings.breakSelectElementsPerLine;
+            gen.Options.NewLineBeforeWhereClause = formatSettings.breakSelectElementsPerLine;
+            gen.Options.NewLineBeforeJoinClause = formatSettings.breakSelectElementsPerLine;
+            gen.Options.NewLineBeforeCloseParenthesisInMultilineList = formatSettings.formatTableDefinitionsMultiline || formatSettings.breakSelectElementsPerLine;
             gen.Options.SqlVersion = SqlVersion.Sql170; //TODO - try to get from current connection
 
             if (formatSettings.preserveComments)
@@ -338,8 +388,221 @@ namespace AxialSqlTools
                 }
             }
 
+            resultCode = PreserveLeadingCommaIndentAfterInlineComments(oldCode, resultCode);
+            resultCode = PreserveSourceTerminalShape(oldCode, resultCode);
             return resultCode;
 
+        }
+
+        private static string PreserveLeadingCommaIndentAfterInlineComments(string oldCode, string resultCode)
+        {
+            if (string.IsNullOrEmpty(oldCode) || string.IsNullOrEmpty(resultCode))
+            {
+                return resultCode;
+            }
+
+            var originalLines = NormalizeLineEndings(oldCode).Split(new[] { "\r\n" }, StringSplitOptions.None);
+            var resultLines = NormalizeLineEndings(resultCode).Split(new[] { "\r\n" }, StringSplitOptions.None);
+            int searchStart = 0;
+
+            for (int i = 0; i < originalLines.Length - 1; i++)
+            {
+                string originalCommentLine = originalLines[i];
+                string originalNextLine = originalLines[i + 1];
+                if (!HasInlineComment(originalCommentLine) || !IsLeadingCommaLine(originalNextLine))
+                {
+                    continue;
+                }
+
+                string originalIndent = LeadingWhitespace(originalNextLine);
+                string commentLineKey = originalCommentLine.TrimEnd();
+                for (int j = searchStart; j < resultLines.Length - 1; j++)
+                {
+                    if (resultLines[j].TrimEnd() != commentLineKey || !IsLeadingCommaLine(resultLines[j + 1]))
+                    {
+                        continue;
+                    }
+
+                    resultLines[j + 1] = originalIndent + resultLines[j + 1].TrimStart();
+                    searchStart = j + 1;
+                    break;
+                }
+            }
+
+            string result = string.Join("\r\n", resultLines);
+            if (!EndsWithLineBreak(resultCode))
+            {
+                result = result.TrimEnd('\r', '\n');
+            }
+
+            return result;
+        }
+
+        private static bool HasInlineComment(string line)
+        {
+            int commentIndex = (line ?? string.Empty).IndexOf("--", StringComparison.Ordinal);
+            return commentIndex > 0 && !string.IsNullOrWhiteSpace(line.Substring(0, commentIndex));
+        }
+
+        private static bool IsLeadingCommaLine(string line)
+        {
+            return Regex.IsMatch(line ?? string.Empty, @"^\s*,");
+        }
+
+        private static string LeadingWhitespace(string line)
+        {
+            return Regex.Match(line ?? string.Empty, @"^\s*").Value;
+        }
+
+        private static string PreserveSourceTerminalShape(string oldCode, string resultCode)
+        {
+            if (string.IsNullOrEmpty(resultCode))
+            {
+                return resultCode;
+            }
+
+            string result = resultCode;
+            if (!LastSignificantCharacterIs(oldCode, ';') && LastSignificantCharacterIs(result, ';'))
+            {
+                int semicolonIndex = LastSignificantCharacterIndex(result);
+                result = result.Remove(semicolonIndex, 1);
+            }
+
+            result = MatchTrailingLineBreaks(oldCode, result);
+
+            return result;
+        }
+
+        private static string MatchTrailingLineBreaks(string oldCode, string resultCode)
+        {
+            int oldTrailingLineBreaks = CountTrailingLineBreaks(oldCode);
+            string result = (resultCode ?? string.Empty).TrimEnd('\r', '\n');
+            string lineEnding = DetectLineEnding(oldCode);
+            for (int i = 0; i < oldTrailingLineBreaks; i++)
+            {
+                result += lineEnding;
+            }
+
+            return result;
+        }
+
+        private static int CountTrailingLineBreaks(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return 0;
+            }
+
+            int count = 0;
+            int i = text.Length;
+            while (i > 0)
+            {
+                if (text[i - 1] == '\n')
+                {
+                    count++;
+                    i--;
+                    if (i > 0 && text[i - 1] == '\r')
+                    {
+                        i--;
+                    }
+                }
+                else if (text[i - 1] == '\r')
+                {
+                    count++;
+                    i--;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            return count;
+        }
+
+        private static string DetectLineEnding(string text)
+        {
+            if (!string.IsNullOrEmpty(text))
+            {
+                int crlf = text.IndexOf("\r\n", StringComparison.Ordinal);
+                if (crlf >= 0)
+                {
+                    return "\r\n";
+                }
+
+                if (text.IndexOf('\n') >= 0)
+                {
+                    return "\n";
+                }
+
+                if (text.IndexOf('\r') >= 0)
+                {
+                    return "\r";
+                }
+            }
+
+            return Environment.NewLine;
+        }
+
+        private static bool LastSignificantCharacterIs(string text, char expected)
+        {
+            int index = LastSignificantCharacterIndex(text);
+            return index >= 0 && text[index] == expected;
+        }
+
+        private static int LastSignificantCharacterIndex(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return -1;
+            }
+
+            for (int i = text.Length - 1; i >= 0; i--)
+            {
+                if (!char.IsWhiteSpace(text[i]))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        private static bool EndsWithLineBreak(string text)
+        {
+            return !string.IsNullOrEmpty(text)
+                && (text.EndsWith("\r\n", StringComparison.Ordinal)
+                    || text.EndsWith("\n", StringComparison.Ordinal)
+                    || text.EndsWith("\r", StringComparison.Ordinal));
+        }
+
+        private static bool HasTransformFormattingEnabled(SettingsManager.TSqlCodeFormatSettings formatSettings)
+        {
+            if (formatSettings == null)
+            {
+                return false;
+            }
+
+            return formatSettings.removeNewLineAfterJoin
+                || formatSettings.addTabAfterJoinOn
+                || formatSettings.moveCrossJoinToNewLine
+                || formatSettings.formatCaseAsMultiline
+                || formatSettings.addNewLineBetweenStatementsInBlocks
+                || formatSettings.breakSprocParametersPerLine
+                || formatSettings.uppercaseBuiltInFunctions
+                || formatSettings.unindentBeginEndBlocks
+                || formatSettings.breakVariableDefinitionsPerLine
+                || formatSettings.breakSprocDefinitionParametersPerLine
+                || formatSettings.breakSelectFieldsAfterTopAndUnindent
+                || formatSettings.leadingCommas
+                || formatSettings.semicolonBeforeCte
+                || formatSettings.breakSelectElementsPerLine
+                || formatSettings.useAssignmentAliases
+                || formatSettings.omitAsForTableAliases
+                || formatSettings.omitAsInDeclare
+                || formatSettings.formatTableDefinitionsMultiline
+                || formatSettings.prefixUnicodeStrings
+                || formatSettings.removeSemicolonsFromDeclare;
         }
 
         private static string ApplySpecialFormat(string oldCode, TSql170Parser sqlParser, SettingsManager.TSqlCodeFormatSettings formatSettings)
@@ -857,6 +1120,18 @@ namespace AxialSqlTools
                 //}
             }
 
+            // special case #12 - place commas at the start of continuation lines
+            if (formatSettings.leadingCommas)
+            {
+                ApplyLeadingCommas(sqlFragment.ScriptTokenStream);
+            }
+
+            // special case #13 - add a defensive semicolon immediately before CTE WITH
+            if (formatSettings.semicolonBeforeCte)
+            {
+                ApplySemicolonBeforeCtes(sqlFragment.ScriptTokenStream, visitor.StatementsWithCtes);
+            }
+
             // return full recompiled result
             StringBuilder sqlText = new StringBuilder();
             foreach (var Token in sqlFragment.ScriptTokenStream)
@@ -864,7 +1139,662 @@ namespace AxialSqlTools
                 sqlText.Append(Token.Text);
             }
 
-            return sqlText.ToString();
+            return ApplyTextFormat(sqlText.ToString(), formatSettings);
+        }
+
+        private static string ApplyTextFormat(string sql, SettingsManager.TSqlCodeFormatSettings formatSettings)
+        {
+            string result = NormalizeLineEndings(sql).Replace("\t", "    ").TrimStart('\r', '\n');
+
+            if (formatSettings.omitAsInDeclare)
+            {
+                result = RemoveAsInDeclareStatements(result);
+            }
+
+            if (formatSettings.omitAsForTableAliases)
+            {
+                result = RemoveAsForTableAliases(result);
+            }
+
+            if (formatSettings.formatTableDefinitionsMultiline)
+            {
+                result = FormatTableVariableDefinitions(result);
+            }
+
+            if (formatSettings.breakSelectElementsPerLine)
+            {
+                result = FormatSelectLists(result, formatSettings.leadingCommas);
+                result = FormatCteSelectOpen(result);
+            }
+
+            if (formatSettings.leadingCommas)
+            {
+                result = NormalizeLeadingCommaLines(result);
+            }
+
+            if (formatSettings.useAssignmentAliases)
+            {
+                result = ApplyAssignmentAliases(result);
+            }
+
+            if (formatSettings.prefixUnicodeStrings)
+            {
+                result = PrefixUnicodeStringLiterals(result);
+            }
+
+            if (formatSettings.removeSemicolonsFromDeclare)
+            {
+                result = RemoveDeclareSemicolons(result);
+            }
+
+            if (formatSettings.leadingCommas)
+            {
+                result = NormalizeLeadingCommaLines(result);
+            }
+
+            if (formatSettings.breakSelectElementsPerLine)
+            {
+                result = FormatCteSelectOpen(result);
+                result = NormalizeCteJoinIndent(result);
+                result = FormatExistingMultilineSelects(result, formatSettings.leadingCommas);
+            }
+
+            result = NormalizeInlineCommentSpacing(result);
+            result = TrimTrailingSpaces(result);
+
+            return NormalizeLineEndings(result);
+        }
+
+        private static string RemoveAsInDeclareStatements(string sql)
+        {
+            return Regex.Replace(
+                sql,
+                @"(?im)^(\s*(?:DECLARE\s+)?[,]?@\w+)\s+AS\s+",
+                "$1 ");
+        }
+
+        private static string RemoveAsForTableAliases(string sql)
+        {
+            return Regex.Replace(
+                sql,
+                @"(?i)\b(FROM|JOIN|APPLY)\s+(@?\[?[\w.]+\]?)\s+AS\s+(\[?\w+\]?)",
+                "$1 $2 $3");
+        }
+
+        private static string FormatTableVariableDefinitions(string sql)
+        {
+            var result = new StringBuilder();
+            int position = 0;
+            var regex = new Regex(@"(?im)^(?<indent>[ \t]*)DECLARE\s+(?<name>@\w+)\s+TABLE\s*\(");
+
+            foreach (Match match in regex.Matches(sql))
+            {
+                if (match.Index < position)
+                {
+                    continue;
+                }
+
+                int openParen = sql.IndexOf('(', match.Index + match.Length - 1);
+                int closeParen = FindMatchingParen(sql, openParen);
+                if (openParen < 0 || closeParen < 0)
+                {
+                    continue;
+                }
+
+                int end = closeParen + 1;
+                if (end < sql.Length && sql[end] == ';')
+                {
+                    end++;
+                }
+
+                string indent = match.Groups["indent"].Value;
+                string childIndent = indent + "    ";
+                string body = Regex.Replace(sql.Substring(openParen + 1, closeParen - openParen - 1), @"\s+", " ").Trim();
+                var columns = SplitTopLevelCommaList(body);
+                var builder = new StringBuilder();
+                builder.Append(indent).Append("DECLARE ").Append(match.Groups["name"].Value).Append(" TABLE (");
+
+                for (int i = 0; i < columns.Count; i++)
+                {
+                    builder.Append("\r\n").Append(childIndent);
+                    if (i > 0)
+                    {
+                        builder.Append(",");
+                    }
+                    builder.Append(NormalizeSpaces(columns[i]));
+                }
+
+                builder.Append("\r\n").Append(indent).Append(")");
+
+                result.Append(sql.Substring(position, match.Index - position));
+                result.Append(builder.ToString());
+                position = end;
+            }
+
+            result.Append(sql.Substring(position));
+            return result.ToString();
+        }
+
+        private static string ApplyAssignmentAliases(string sql)
+        {
+            string result = sql;
+
+            result = Regex.Replace(
+                result,
+                @"(?ims)^(?<indent>\s*)(?<comma>,?)(?<post>\s*)CASE\r?\n(?<body>.*?)^(?<endindent>\s*)END\s+AS\s+(?<alias>\w+)\s*$",
+                match =>
+                {
+                    string indent = EffectiveCommaIndent(match);
+                    string comma = string.IsNullOrEmpty(match.Groups["comma"].Value) ? string.Empty : ",";
+                    string body = ReindentCaseBody(match.Groups["body"].Value, indent + "        ");
+                    return $"{indent}{comma}{match.Groups["alias"].Value} =\r\n{indent}    CASE\r\n{body}\r\n{indent}    END";
+                });
+
+            result = Regex.Replace(
+                result,
+                @"(?im)^(?<indent>\s*)(?<comma>,?)(?<post>\s*)(?<expr>(?:[A-Z_][\w.]*\s*)?\([^\r\n]*\)|[\w.]+)\s+AS\s+(?<alias>\w+)\s*$",
+                match =>
+                {
+                    string indent = EffectiveCommaIndent(match);
+                    string comma = string.IsNullOrEmpty(match.Groups["comma"].Value) ? string.Empty : ",";
+                    return $"{indent}{comma}{match.Groups["alias"].Value} = {match.Groups["expr"].Value.Trim()}";
+                });
+
+            return result;
+        }
+
+        private static string FormatSelectLists(string sql, bool leadingCommas)
+        {
+            return Regex.Replace(
+                sql,
+                @"(?im)^(?<indent>[ \t]*)SELECT(?<top>\s+TOP\s+\(?\d+\)?)?\s+(?<items>.+?(?:--.*)?)$",
+                match =>
+                {
+                    string itemsText = match.Groups["items"].Value;
+                    if (!itemsText.Contains(",") || Regex.IsMatch(itemsText, @"(?i)\bFROM\b"))
+                    {
+                        return match.Value;
+                    }
+
+                    string indent = match.Groups["indent"].Value;
+                    string childIndent = indent + "    ";
+                    var items = SplitTopLevelCommaList(itemsText);
+                    if (items.Count <= 1)
+                    {
+                        return match.Value;
+                    }
+
+                    var builder = new StringBuilder();
+                    builder.Append(indent).Append("SELECT").Append(match.Groups["top"].Value);
+                    for (int i = 0; i < items.Count; i++)
+                    {
+                        builder.Append("\r\n").Append(childIndent);
+                        if (i > 0 && leadingCommas)
+                        {
+                            builder.Append(",");
+                        }
+                        builder.Append(items[i].Trim());
+                        if (i < items.Count - 1 && !leadingCommas)
+                        {
+                            builder.Append(",");
+                        }
+                    }
+
+                    return builder.ToString();
+                });
+        }
+
+        private static string FormatCteSelectOpen(string sql)
+        {
+            string result = Regex.Replace(
+                sql,
+                @"(?im)^(?<indent>[ \t]*);?WITH\s+(?<name>\w+)[ \t]*\r?\n[ \t]*AS\s*\(SELECT(?<top>\s+TOP\s+\(?\d+\)?)?\s+(?<first>[^\r\n,]+)",
+                match =>
+                {
+                    string indent = match.Groups["indent"].Value;
+                    return $"{indent};WITH {match.Groups["name"].Value} AS (\r\n{indent}    SELECT{match.Groups["top"].Value}\r\n{indent}        {match.Groups["first"].Value.Trim()}";
+                });
+
+            result = Regex.Replace(
+                result,
+                @"(?im)^(?<indent>[ \t]*)(?<join>INNER|LEFT|RIGHT|FULL)\s+JOIN\s*\r?\n[ \t]*(?<table>@?\w+\s+\w+)\s*$",
+                "${indent}${join} JOIN ${table}");
+
+            result = Regex.Replace(
+                result,
+                @"(?im)^(?<indent>[ \t]*)(?<line>CROSS\s+JOIN\s+@?\w+\s+\w+)\)$",
+                "${indent}${line}\r\n${indent})");
+
+            return result;
+        }
+
+        private static string NormalizeCteJoinIndent(string sql)
+        {
+            var lines = NormalizeLineEndings(sql).Split(new[] { "\r\n" }, StringSplitOptions.None);
+            bool insideCte = false;
+            string cteIndent = string.Empty;
+            string fromIndent = string.Empty;
+            var output = new List<string>();
+
+            foreach (string originalLine in lines)
+            {
+                string line = originalLine;
+                string trimmed = line.TrimStart();
+                string currentIndent = Regex.Match(line, @"^[ \t]*").Value;
+
+                if (Regex.IsMatch(trimmed, @"^;WITH\b", RegexOptions.IgnoreCase))
+                {
+                    insideCte = true;
+                    cteIndent = currentIndent;
+                    fromIndent = string.Empty;
+                    output.Add(line);
+                    continue;
+                }
+
+                if (insideCte && Regex.IsMatch(trimmed, @"^FROM\b", RegexOptions.IgnoreCase))
+                {
+                    fromIndent = currentIndent;
+                    output.Add(line);
+                    continue;
+                }
+
+                if (insideCte && !string.IsNullOrEmpty(fromIndent))
+                {
+                    if (Regex.IsMatch(trimmed, @"^(INNER|LEFT|RIGHT|FULL|CROSS)\s+JOIN\b", RegexOptions.IgnoreCase))
+                    {
+                        bool closesCte = trimmed.EndsWith(")", StringComparison.Ordinal);
+                        string joinText = closesCte ? trimmed.Substring(0, trimmed.Length - 1).TrimEnd() : trimmed;
+                        output.Add(fromIndent + joinText);
+                        if (closesCte)
+                        {
+                            output.Add(cteIndent + ")");
+                            insideCte = false;
+                            fromIndent = string.Empty;
+                        }
+
+                        continue;
+                    }
+
+                    if (Regex.IsMatch(trimmed, @"^ON\b", RegexOptions.IgnoreCase))
+                    {
+                        output.Add(fromIndent + "    " + trimmed);
+                        continue;
+                    }
+                }
+
+                if (insideCte && trimmed == ")")
+                {
+                    output.Add(cteIndent + ")");
+                    insideCte = false;
+                    fromIndent = string.Empty;
+                    continue;
+                }
+
+                output.Add(line);
+            }
+
+            return string.Join("\r\n", output);
+        }
+
+        private static string FormatExistingMultilineSelects(string sql, bool leadingCommas)
+        {
+            return Regex.Replace(
+                sql,
+                @"(?im)^(?<indent>[ \t]*)SELECT\s+(?<first>[^\r\n,]+)\r?\n(?<items>(?:[ \t]*,[^\r\n]*(?:\r?\n|$)){1,})",
+                match =>
+                {
+                    string indent = match.Groups["indent"].Value;
+                    string childIndent = indent + "    ";
+                    var items = new List<string> { match.Groups["first"].Value.Trim() };
+                    foreach (Match itemMatch in Regex.Matches(match.Groups["items"].Value, @"(?m)^[ \t]*,(?<item>[^\r\n]*)"))
+                    {
+                        items.Add(itemMatch.Groups["item"].Value.Trim());
+                    }
+
+                    if (items.Count <= 1)
+                    {
+                        return match.Value;
+                    }
+
+                    var builder = new StringBuilder();
+                    builder.Append(indent).Append("SELECT");
+                    for (int i = 0; i < items.Count; i++)
+                    {
+                        builder.Append("\r\n").Append(childIndent);
+                        if (i > 0 && leadingCommas)
+                        {
+                            builder.Append(",");
+                        }
+
+                        builder.Append(items[i]);
+                        if (i < items.Count - 1 && !leadingCommas)
+                        {
+                            builder.Append(",");
+                        }
+                    }
+
+                    return builder.ToString();
+                });
+        }
+
+        private static string NormalizeLeadingCommaLines(string sql)
+        {
+            var lines = NormalizeLineEndings(sql).Split(new[] { "\r\n" }, StringSplitOptions.None);
+            string previousItemIndent = string.Empty;
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string line = lines[i];
+                Match commaMatch = Regex.Match(line, @"^(?<indent>\s*),(?<space>\s*)(?<text>.*)$");
+                if (commaMatch.Success)
+                {
+                    string candidateIndent = commaMatch.Groups["indent"].Value;
+                    string indent = string.IsNullOrEmpty(candidateIndent)
+                        ? previousItemIndent
+                        : candidateIndent;
+                    if (!string.IsNullOrEmpty(previousItemIndent)
+                        && candidateIndent.Length > previousItemIndent.Length + 4)
+                    {
+                        indent = previousItemIndent;
+                    }
+
+                    lines[i] = indent + "," + commaMatch.Groups["text"].Value.TrimStart();
+                    previousItemIndent = indent;
+                    continue;
+                }
+
+                if (!string.IsNullOrWhiteSpace(line)
+                    && !Regex.IsMatch(line.TrimStart(), @"^(SELECT|FROM|WHERE|INNER|LEFT|RIGHT|FULL|CROSS|ON|ELSE|END|\)|;WITH)\b", RegexOptions.IgnoreCase))
+                {
+                    previousItemIndent = Regex.Match(line, @"^\s*").Value;
+                }
+            }
+
+            return string.Join("\r\n", lines);
+        }
+
+        private static string EffectiveCommaIndent(Match match)
+        {
+            string indent = match.Groups["indent"].Value;
+            if (string.IsNullOrEmpty(indent) && !string.IsNullOrEmpty(match.Groups["comma"].Value))
+            {
+                indent = match.Groups["post"].Value;
+            }
+
+            return indent;
+        }
+
+        private static int FindMatchingParen(string text, int openParen)
+        {
+            if (openParen < 0)
+            {
+                return -1;
+            }
+
+            int depth = 0;
+            for (int i = openParen; i < text.Length; i++)
+            {
+                if (text[i] == '(')
+                {
+                    depth++;
+                }
+                else if (text[i] == ')')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        return i;
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        private static string ReindentCaseBody(string body, string indent)
+        {
+            var sourceLines = NormalizeLineEndings(body).Split(new[] { "\r\n" }, StringSplitOptions.None)
+                .Where(line => !string.IsNullOrWhiteSpace(line))
+                .Select(line => line.Trim())
+                .ToList();
+
+            var lines = new List<string>();
+            for (int i = 0; i < sourceLines.Count; i++)
+            {
+                string line = sourceLines[i];
+                if (line.StartsWith("WHEN ", StringComparison.OrdinalIgnoreCase)
+                    && i + 1 < sourceLines.Count
+                    && sourceLines[i + 1].StartsWith("THEN ", StringComparison.OrdinalIgnoreCase))
+                {
+                    lines.Add(indent + line + " " + sourceLines[i + 1]);
+                    i++;
+                    continue;
+                }
+
+                lines.Add(indent + line);
+            }
+
+            return string.Join("\r\n", lines);
+        }
+
+        private static string NormalizeInlineCommentSpacing(string sql)
+        {
+            return Regex.Replace(
+                sql,
+                @"(?m)(--[^\r\n]*)\r\n[ \t]*\r\n([ \t]*(?:FROM|WHERE|GROUP|ORDER|HAVING)\b)",
+                "$1\r\n$2");
+        }
+
+        private static string TrimTrailingSpaces(string sql)
+        {
+            return Regex.Replace(sql, @"(?m)[ \t]+(?=\r?$)", string.Empty);
+        }
+
+        private static string PrefixUnicodeStringLiterals(string sql)
+        {
+            var builder = new StringBuilder();
+            for (int i = 0; i < sql.Length; i++)
+            {
+                if (i + 1 < sql.Length && sql[i] == '-' && sql[i + 1] == '-')
+                {
+                    int end = sql.IndexOf('\n', i + 2);
+                    if (end < 0)
+                    {
+                        builder.Append(sql.Substring(i));
+                        break;
+                    }
+
+                    builder.Append(sql.Substring(i, end - i + 1));
+                    i = end;
+                    continue;
+                }
+
+                if (i + 1 < sql.Length && sql[i] == '/' && sql[i + 1] == '*')
+                {
+                    int end = sql.IndexOf("*/", i + 2, StringComparison.Ordinal);
+                    if (end < 0)
+                    {
+                        builder.Append(sql.Substring(i));
+                        break;
+                    }
+
+                    builder.Append(sql.Substring(i, end - i + 2));
+                    i = end + 1;
+                    continue;
+                }
+
+                if (sql[i] == '\'')
+                {
+                    if (i == 0 || (sql[i - 1] != 'N' && sql[i - 1] != 'n'))
+                    {
+                        builder.Append('N');
+                    }
+
+                    builder.Append(sql[i]);
+                    while (++i < sql.Length)
+                    {
+                        builder.Append(sql[i]);
+                        if (sql[i] == '\'')
+                        {
+                            if (i + 1 < sql.Length && sql[i + 1] == '\'')
+                            {
+                                builder.Append(sql[++i]);
+                                continue;
+                            }
+
+                            break;
+                        }
+                    }
+
+                    continue;
+                }
+
+                builder.Append(sql[i]);
+            }
+
+            return builder.ToString();
+        }
+
+        private static string RemoveDeclareSemicolons(string sql)
+        {
+            return Regex.Replace(sql, @"(?im)^(\s*(?:DECLARE\b|,@).*?);(\s*)$", "$1$2");
+        }
+
+        private static List<string> SplitTopLevelCommaList(string text)
+        {
+            var items = new List<string>();
+            int depth = 0;
+            int start = 0;
+
+            for (int i = 0; i < text.Length; i++)
+            {
+                char ch = text[i];
+                if (ch == '(')
+                {
+                    depth++;
+                }
+                else if (ch == ')' && depth > 0)
+                {
+                    depth--;
+                }
+                else if (ch == ',' && depth == 0)
+                {
+                    items.Add(text.Substring(start, i - start).Trim());
+                    start = i + 1;
+                }
+            }
+
+            if (start < text.Length)
+            {
+                items.Add(text.Substring(start).Trim());
+            }
+
+            return items;
+        }
+
+        private static string NormalizeSpaces(string text)
+        {
+            return Regex.Replace(text ?? string.Empty, @"\s+", " ").Trim();
+        }
+
+        private static string NormalizeLineEndings(string text)
+        {
+            return (text ?? string.Empty).Replace("\r\n", "\n").Replace("\r", "\n").Replace("\n", "\r\n");
+        }
+
+        private static void ApplyLeadingCommas(IList<TSqlParserToken> tokens)
+        {
+            for (int i = 0; i < tokens.Count - 1; i++)
+            {
+                if (tokens[i].TokenType != TSqlTokenType.Comma)
+                {
+                    continue;
+                }
+
+                int wsAfterComma = i + 1;
+                if (tokens[wsAfterComma].TokenType != TSqlTokenType.WhiteSpace
+                    || !ContainsNewLine(tokens[wsAfterComma].Text))
+                {
+                    continue;
+                }
+
+                tokens[i].Text = string.Empty;
+                tokens[wsAfterComma].Text = MoveCommaToContinuationLine(tokens[wsAfterComma].Text);
+            }
+        }
+
+        private static void ApplySemicolonBeforeCtes(
+            IList<TSqlParserToken> tokens,
+            IList<StatementWithCtesAndXmlNamespaces> statementsWithCtes)
+        {
+            foreach (var statement in statementsWithCtes)
+            {
+                if (statement.FirstTokenIndex < 0 || statement.FirstTokenIndex >= tokens.Count)
+                {
+                    continue;
+                }
+
+                int cteTokenIndex = statement.FirstTokenIndex;
+                int previousSignificantTokenIndex = cteTokenIndex - 1;
+                while (previousSignificantTokenIndex >= 0
+                    && tokens[previousSignificantTokenIndex].TokenType == TSqlTokenType.WhiteSpace)
+                {
+                    previousSignificantTokenIndex--;
+                }
+
+                int whitespaceBeforeCte = cteTokenIndex - 1;
+                if (previousSignificantTokenIndex >= 0
+                    && tokens[previousSignificantTokenIndex].TokenType == TSqlTokenType.Semicolon)
+                {
+                    if (previousSignificantTokenIndex == cteTokenIndex - 1)
+                    {
+                        continue;
+                    }
+
+                    tokens[previousSignificantTokenIndex].Text = string.Empty;
+                }
+
+                if (whitespaceBeforeCte >= 0
+                    && tokens[whitespaceBeforeCte].TokenType == TSqlTokenType.WhiteSpace)
+                {
+                    tokens[whitespaceBeforeCte].Text = tokens[whitespaceBeforeCte].Text + ";";
+                }
+                else
+                {
+                    tokens[cteTokenIndex].Text = ";" + tokens[cteTokenIndex].Text;
+                }
+            }
+        }
+
+        private static bool ContainsNewLine(string text)
+        {
+            return text != null && (text.Contains("\r\n") || text.Contains("\n"));
+        }
+
+        private static string MoveCommaToContinuationLine(string whitespace)
+        {
+            if (string.IsNullOrEmpty(whitespace))
+            {
+                return ",";
+            }
+
+            int newlineIndex = whitespace.LastIndexOf("\r\n", StringComparison.Ordinal);
+            int newlineLength = 2;
+
+            if (newlineIndex < 0)
+            {
+                newlineIndex = whitespace.LastIndexOf("\n", StringComparison.Ordinal);
+                newlineLength = 1;
+            }
+
+            if (newlineIndex < 0)
+            {
+                return "," + whitespace;
+            }
+
+            return whitespace.Substring(newlineIndex, newlineLength)
+                + whitespace.Substring(newlineIndex + newlineLength)
+                + ",";
         }
 
         // Helper: for a whitespace token that looks like "\r\n    …",

--- a/AxialSqlTools/Modules/TsqlFormatterCommentInterleaver.cs
+++ b/AxialSqlTools/Modules/TsqlFormatterCommentInterleaver.cs
@@ -53,15 +53,22 @@ public static class TsqlFormatterCommentInterleaver
             mapOrigToFmt[origCodeIdx[iOrigKey]] = fmtCodeIdx[iFmtKey];
         }
 
-        // Collect comments from original and schedule injection BEFORE a formatted code token.
+        // Collect comments from original and schedule injection around formatted code tokens.
         var injectBeforeFmtIndex = new Dictionary<int, List<CommentCluster>>();
+        var injectAfterFmtIndex = new Dictionary<int, List<CommentCluster>>();
         var eofComments = new List<CommentCluster>();
 
-        // Helper to add a comment to a bucket
-        void Schedule(int fmtIndex, CommentCluster cluster)
+        void ScheduleBefore(int fmtIndex, CommentCluster cluster)
         {
             if (!injectBeforeFmtIndex.TryGetValue(fmtIndex, out var list))
                 injectBeforeFmtIndex[fmtIndex] = list = new List<CommentCluster>();
+            list.Add(cluster);
+        }
+
+        void ScheduleAfter(int fmtIndex, CommentCluster cluster)
+        {
+            if (!injectAfterFmtIndex.TryGetValue(fmtIndex, out var list))
+                injectAfterFmtIndex[fmtIndex] = list = new List<CommentCluster>();
             list.Add(cluster);
         }
 
@@ -87,8 +94,18 @@ public static class TsqlFormatterCommentInterleaver
 
             var cluster = new CommentCluster(chunk.ToString(), startsNewLine, blankLinesBefore);
 
+            if (!startsNewLine)
+            {
+                int previousCode = FindPreviousCodeToken(orig, i);
+                if (previousCode >= 0 && mapOrigToFmt.TryGetValue(previousCode, out int fmtPreviousIndex))
+                {
+                    ScheduleAfter(fmtPreviousIndex, cluster);
+                    continue;
+                }
+            }
+
             if (anchorOrig >= 0 && mapOrigToFmt.TryGetValue(anchorOrig, out int fmtIndex))
-                Schedule(fmtIndex, cluster);
+                ScheduleBefore(fmtIndex, cluster);
             else
                 eofComments.Add(cluster);
         }
@@ -122,6 +139,22 @@ public static class TsqlFormatterCommentInterleaver
             }
 
             sb.Append(fmt[jCode].Text);
+            if (injectAfterFmtIndex.TryGetValue(jCode, out var afterInject))
+            {
+                foreach (var c in afterInject)
+                {
+                    if (c.StartsNewLine && !EndsWithNewline(sb))
+                    {
+                        sb.Append(Environment.NewLine);
+                    }
+                    else if (!c.StartsNewLine && sb.Length > 0 && !char.IsWhiteSpace(sb[sb.Length - 1]))
+                    {
+                        sb.Append(' ');
+                    }
+
+                    sb.Append(c.StartsNewLine ? c.Text : c.Text);
+                }
+            }
             cur++;
         }
 
@@ -304,6 +337,24 @@ public static class TsqlFormatterCommentInterleaver
         }
 
         return idx;
+    }
+
+    private static int FindPreviousCodeToken(IList<TSqlParserToken> tokens, int start)
+    {
+        for (int i = start - 1; i >= 0; i--)
+        {
+            if (IsCodeToken(tokens[i]))
+            {
+                return i;
+            }
+
+            if (!IsWhitespaceToken(tokens[i]) && !IsCommentToken(tokens[i]))
+            {
+                return -1;
+            }
+        }
+
+        return -1;
     }
 
     private static int TrailingNewlines(StringBuilder sb)

--- a/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
+++ b/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml
@@ -87,6 +87,10 @@
                     </Setter.Value>
                 </Setter>
             </Style>
+
+            <Style TargetType="RadioButton">
+                <Setter Property="Foreground" Value="{DynamicResource AxialThemeForegroundBrush}" />
+            </Style>
         </ResourceDictionary>
     </UserControl.Resources>
     
@@ -401,12 +405,6 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
 
@@ -420,8 +418,26 @@
                         </Hyperlink>
                     </TextBlock>
 
+                    <StackPanel Grid.Row="1"
+                                Orientation="Horizontal"
+                                Margin="5"
+                                VerticalAlignment="Center">
+                        <TextBlock Text="Formatting setup:" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                        <RadioButton x:Name="FormatModeOptions"
+                                     Content="Options"
+                                     GroupName="FormatMode"
+                                     IsChecked="True"
+                                     Margin="0,0,15,0"
+                                     Checked="FormatMode_Checked"/>
+                        <RadioButton x:Name="FormatModeFreehand"
+                                     Content="Learn from example"
+                                     GroupName="FormatMode"
+                                     Checked="FormatMode_Checked"/>
+                    </StackPanel>
+
                     <!-- all checkboxes in a 3-column UniformGrid -->
-                    <UniformGrid Grid.Row="1"
+                    <UniformGrid Grid.Row="2"
+                             x:Name="FormatOptionsPanel"
                              Columns="3"
                              Margin="5"
                              HorizontalAlignment="Left">
@@ -469,6 +485,38 @@
                               Content="Break sproc definition parameters per line" 
                               Checked="formatSetting_Checked"
                               Unchecked="formatSetting_Unchecked"/>
+                        <CheckBox x:Name="LeadingCommas" Margin="5"
+                              Content="Use leading commas" 
+                              Checked="formatSetting_Checked"
+                              Unchecked="formatSetting_Unchecked"/>
+                        <CheckBox x:Name="SemicolonBeforeCte" Margin="5"
+                              Content="Put semicolon before CTE" 
+                              Checked="formatSetting_Checked"
+                              Unchecked="formatSetting_Unchecked"/>
+                        <CheckBox x:Name="BreakSelectElementsPerLine" Margin="5"
+                              Content="Put SELECT fields on separate lines"
+                              Checked="formatSetting_Checked"
+                              Unchecked="formatSetting_Unchecked"/>
+                        <CheckBox x:Name="UseAssignmentAliases" Margin="5"
+                              Content="Use alias = expression for column aliases"
+                              Checked="formatSetting_Checked"
+                              Unchecked="formatSetting_Unchecked"/>
+                        <CheckBox x:Name="OmitAsForTableAliases" Margin="5"
+                              Content="Omit AS for table aliases"
+                              Checked="formatSetting_Checked"
+                              Unchecked="formatSetting_Unchecked"/>
+                        <CheckBox x:Name="OmitAsInDeclare" Margin="5"
+                              Content="Omit AS in DECLARE types"
+                              Checked="formatSetting_Checked"
+                              Unchecked="formatSetting_Unchecked"/>
+                        <CheckBox x:Name="FormatTableDefinitionsMultiline" Margin="5"
+                              Content="Put table variable columns on separate lines"
+                              Checked="formatSetting_Checked"
+                              Unchecked="formatSetting_Unchecked"/>
+                        <CheckBox x:Name="PrefixUnicodeStrings" Margin="5"
+                              Content="Prefix string literals with N"
+                              Checked="formatSetting_Checked"
+                              Unchecked="formatSetting_Unchecked"/>
                         <!-- TODO -->
                         <CheckBox x:Name="BreakSelectFieldsAfterTopAndUnindent" Margin="5" Visibility="Hidden"
                               Content="Break SELECT fields after TOP and unindent" 
@@ -478,7 +526,7 @@
                     </UniformGrid>
 
                     <Button
-                        Grid.Row="9"
+                        Grid.Row="3"
                         x:Name="button_SaveApplyAdditionalFormat"
                         Click="Button_SaveApplyAdditionalFormat_Click"
                         Width="80" 
@@ -494,7 +542,60 @@
                         </StackPanel>
                     </Button>
 
-                    <Grid Grid.Row="10">
+                    <GroupBox Grid.Row="4"
+                              x:Name="FreehandFormatPanel"
+                              Header="Format this sample"
+                              Margin="5"
+                              Visibility="Collapsed">
+                        <DockPanel>
+                            <StackPanel DockPanel.Dock="Top"
+                                        Orientation="Horizontal"
+                                        HorizontalAlignment="Right"
+                                        Margin="0,0,0,5">
+                                <Button Content="Open in new tab"
+                                        Click="Button_OpenFreehandSampleInNewTab_Click"
+                                        Padding="10,3"
+                                        Margin="0,0,8,0"/>
+                                <Button Content="Format"
+                                        Click="Button_FormatFreehandSample_Click"
+                                        Padding="10,3"/>
+                            </StackPanel>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+
+                                <GroupBox Header="Source SQL" Grid.Column="0" Margin="0,0,4,0">
+                                    <TextBox x:Name="FreehandSourceEditor"
+                                             AcceptsReturn="True"
+                                             AcceptsTab="True"
+                                             VerticalScrollBarVisibility="Auto"
+                                             HorizontalScrollBarVisibility="Auto"
+                                             TextWrapping="NoWrap"
+                                             FontFamily="Consolas"
+                                             FontSize="13"
+                                             MinHeight="450"
+                                             IsReadOnly="True"/>
+                                </GroupBox>
+
+                                <GroupBox Header="Your formatting" Grid.Column="1" Margin="4,0,0,0">
+                                    <TextBox x:Name="FreehandFormatEditor"
+                                             AcceptsReturn="True"
+                                             AcceptsTab="True"
+                                             VerticalScrollBarVisibility="Auto"
+                                             HorizontalScrollBarVisibility="Auto"
+                                             TextWrapping="NoWrap"
+                                             FontFamily="Consolas"
+                                             FontSize="13"
+                                             MinHeight="450"/>
+                                </GroupBox>
+                            </Grid>
+                        </DockPanel>
+                    </GroupBox>
+
+                    <Grid Grid.Row="4"
+                          x:Name="FormatPreviewPanel">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="*" />

--- a/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml.cs
+++ b/AxialSqlTools/WindowSettings/SettingsWindowControl.xaml.cs
@@ -1,14 +1,19 @@
 ﻿namespace AxialSqlTools
 {
     using Microsoft.Data.SqlClient;
+    using Microsoft.SqlServer.Management.UI.VSIntegration;
+    using Microsoft.SqlServer.Management.UI.VSIntegration.Editors;
+    using Microsoft.SqlServer.TransactSql.ScriptDom;
     using Newtonsoft.Json.Linq;
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.IO.Compression;
     using System.Net.Http;
     using System.Text;
+    using System.Text.RegularExpressions;
     using System.Threading;
     using System.Windows;
     using System.Windows.Controls;
@@ -32,22 +37,23 @@
         private bool updateResultSubscribed;
         private ObservableCollection<SettingsManager.ConnectionColorRule> _connectionColorRules;
 
-        private string tsqlFormatExample = @"while (1=0) 
-begin 
-select top 10
-    c.CustomerID, getDate(),
-    CASE WHEN o.TotalAmount > 1000 THEN 'High' ELSE 'Low' END AS OrderSize
-FROM Customers c
-JOIN Orders o ON c.CustomerID = o.CustomerID CROSS JOIN Regions r
-WHERE c.IsActive = 1;
+        private string tsqlFormatExample = @"-- comment
+IF 0 = 1
+BEGIN
+    DECLARE @a int = 1, @b varchar(10) = 'x';
+    DECLARE @t TABLE (id int, label varchar(10));
+    DECLARE @u TABLE (id int);
 
-SELECT dbo.func(p.ProductID), p.ProductName FROM Products p; EXEC dbo.test @a = 0, @b = 1;
-end
-if 1=0 begin select 1; declare @a int, @b varchar(10) = ''
-end
-go
-create procedure dbo.test @a int, @b int = 0
-as select 1;
+    WITH c AS (
+        SELECT TOP 2 t.id, GETDATE() AS dt, CASE WHEN t.id > @a THEN 'big' ELSE 'small' END AS label
+        FROM @t AS t JOIN @u AS u ON u.id = t.id CROSS JOIN @u AS x
+    )
+    SELECT c.id, c.dt, c.label -- inline comment
+    FROM c
+    WHERE c.label <> @b;
+
+    EXEC dbo.p @a = @a, @b = @b;
+END
 ";
         /// <summary>
         /// Initializes a new instance of the <see cref="SettingsWindowControl"/> class.
@@ -65,6 +71,8 @@ as select 1;
             this.Unloaded += UserControl_Unloaded;
 
             SourceQueryPreview.Text = tsqlFormatExample;
+            FreehandSourceEditor.Text = tsqlFormatExample;
+            FreehandFormatEditor.Text = tsqlFormatExample;
 
             formatTSqlExample();
 
@@ -160,18 +168,12 @@ as select 1;
                 SMTP_EnableSSL.IsChecked = smtpSettings.EnableSsl;
 
                 var tsqlCodeFormatSettings = SettingsManager.GetTSqlCodeFormatSettings();
-                PreserveComments.IsChecked = tsqlCodeFormatSettings.preserveComments;
-                RemoveNewLineAfterJoin.IsChecked = tsqlCodeFormatSettings.removeNewLineAfterJoin;
-                AddTabAfterJoinOn.IsChecked = tsqlCodeFormatSettings.addTabAfterJoinOn;
-                MoveCrossJoinToNewLine.IsChecked = tsqlCodeFormatSettings.moveCrossJoinToNewLine;
-                FormatCaseAsMultiline.IsChecked = tsqlCodeFormatSettings.formatCaseAsMultiline;
-                AddNewLineBetweenStatementsInBlocks.IsChecked = tsqlCodeFormatSettings.addNewLineBetweenStatementsInBlocks;
-                BreakSprocParametersPerLine.IsChecked = tsqlCodeFormatSettings.breakSprocParametersPerLine;
-                UppercaseBuiltInFunctions.IsChecked = tsqlCodeFormatSettings.uppercaseBuiltInFunctions;
-                UnindentBeginEndBlocks.IsChecked = tsqlCodeFormatSettings.unindentBeginEndBlocks;
-                BreakVariableDefinitionsPerLine.IsChecked = tsqlCodeFormatSettings.breakVariableDefinitionsPerLine;  
-                BreakSprocDefinitionParametersPerLine.IsChecked = tsqlCodeFormatSettings.breakSprocDefinitionParametersPerLine;
-                // BreakSelectFieldsAfterTopAndUnindent.IsChecked = tsqlCodeFormatSettings.breakSelectFieldsAfterTopAndUnindent;
+                ApplyTSqlCodeFormatSettingsToUi(tsqlCodeFormatSettings);
+                FormatModeFreehand.IsChecked = tsqlCodeFormatSettings.useFreehandFormatMode;
+                FormatModeOptions.IsChecked = !tsqlCodeFormatSettings.useFreehandFormatMode;
+                FreehandSourceEditor.Text = tsqlFormatExample;
+                FreehandFormatEditor.Text = TSqlFormatter.FormatCode(tsqlFormatExample, tsqlCodeFormatSettings);
+                UpdateFormatModeUi();
 
                 OpenAiApiKey.Password = SettingsManager.GetOpenAiApiKey();
 
@@ -387,23 +389,20 @@ as select 1;
 
         private void Button_SaveApplyAdditionalFormat_Click(object sender, RoutedEventArgs e)
         {
-            var settings = new SettingsManager.TSqlCodeFormatSettings
+            if (FormatModeFreehand.IsChecked == true && !ValidateFreehandFormatSample())
             {
-                preserveComments = PreserveComments.IsChecked.GetValueOrDefault(false),
-                removeNewLineAfterJoin = RemoveNewLineAfterJoin.IsChecked.GetValueOrDefault(false),
-                addTabAfterJoinOn = AddTabAfterJoinOn.IsChecked.GetValueOrDefault(false),
-                moveCrossJoinToNewLine = MoveCrossJoinToNewLine.IsChecked.GetValueOrDefault(false),
-                formatCaseAsMultiline = FormatCaseAsMultiline.IsChecked.GetValueOrDefault(false),
-                addNewLineBetweenStatementsInBlocks = AddNewLineBetweenStatementsInBlocks.IsChecked.GetValueOrDefault(false),
-                breakSprocParametersPerLine = BreakSprocParametersPerLine.IsChecked.GetValueOrDefault(false),
-                uppercaseBuiltInFunctions = UppercaseBuiltInFunctions.IsChecked.GetValueOrDefault(false),
-                unindentBeginEndBlocks = UnindentBeginEndBlocks.IsChecked.GetValueOrDefault(false),
-                breakVariableDefinitionsPerLine = BreakVariableDefinitionsPerLine.IsChecked.GetValueOrDefault(false),
-                breakSprocDefinitionParametersPerLine = BreakSprocDefinitionParametersPerLine.IsChecked.GetValueOrDefault(false),
-                // breakSelectFieldsAfterTopAndUnindent = BreakSelectFieldsAfterTopAndUnindent.IsChecked.GetValueOrDefault(false)
-            };
+                return;
+            }
+
+            var settings = FormatModeFreehand.IsChecked == true
+                ? LearnTSqlFormatSettingsFromSample(FreehandFormatEditor.Text)
+                : BuildTSqlCodeFormatSettingsFromUi();
+
+            settings.useFreehandFormatMode = FormatModeFreehand.IsChecked == true;
 
             SettingsManager.SaveTSqlCodeFormatSettings(settings);
+            ApplyTSqlCodeFormatSettingsToUi(settings);
+            formatTSqlExample();
             SavedMessage();
         }
 
@@ -651,9 +650,9 @@ as select 1;
             });
         }
 
-        private void formatTSqlExample()
+        private SettingsManager.TSqlCodeFormatSettings BuildTSqlCodeFormatSettingsFromUi()
         {
-            var settings = new SettingsManager.TSqlCodeFormatSettings
+            return new SettingsManager.TSqlCodeFormatSettings
             {
                 preserveComments = PreserveComments.IsChecked.GetValueOrDefault(false),
                 removeNewLineAfterJoin = RemoveNewLineAfterJoin.IsChecked.GetValueOrDefault(false),
@@ -666,8 +665,233 @@ as select 1;
                 unindentBeginEndBlocks = UnindentBeginEndBlocks.IsChecked.GetValueOrDefault(false),
                 breakVariableDefinitionsPerLine = BreakVariableDefinitionsPerLine.IsChecked.GetValueOrDefault(false),
                 breakSprocDefinitionParametersPerLine = BreakSprocDefinitionParametersPerLine.IsChecked.GetValueOrDefault(false),
+                leadingCommas = LeadingCommas.IsChecked.GetValueOrDefault(false),
+                semicolonBeforeCte = SemicolonBeforeCte.IsChecked.GetValueOrDefault(false),
+                useFreehandFormatMode = FormatModeFreehand.IsChecked.GetValueOrDefault(false),
+                breakSelectElementsPerLine = BreakSelectElementsPerLine.IsChecked.GetValueOrDefault(false),
+                useAssignmentAliases = UseAssignmentAliases.IsChecked.GetValueOrDefault(false),
+                omitAsForTableAliases = OmitAsForTableAliases.IsChecked.GetValueOrDefault(false),
+                omitAsInDeclare = OmitAsInDeclare.IsChecked.GetValueOrDefault(false),
+                formatTableDefinitionsMultiline = FormatTableDefinitionsMultiline.IsChecked.GetValueOrDefault(false),
+                prefixUnicodeStrings = PrefixUnicodeStrings.IsChecked.GetValueOrDefault(false),
+                removeSemicolonsFromDeclare = FormatTableDefinitionsMultiline.IsChecked.GetValueOrDefault(false),
                 // breakSelectFieldsAfterTopAndUnindent = BreakSelectFieldsAfterTopAndUnindent.IsChecked.GetValueOrDefault(false)
             };
+        }
+
+        private void ApplyTSqlCodeFormatSettingsToUi(SettingsManager.TSqlCodeFormatSettings settings)
+        {
+            PreserveComments.IsChecked = settings.preserveComments;
+            RemoveNewLineAfterJoin.IsChecked = settings.removeNewLineAfterJoin;
+            AddTabAfterJoinOn.IsChecked = settings.addTabAfterJoinOn;
+            MoveCrossJoinToNewLine.IsChecked = settings.moveCrossJoinToNewLine;
+            FormatCaseAsMultiline.IsChecked = settings.formatCaseAsMultiline;
+            AddNewLineBetweenStatementsInBlocks.IsChecked = settings.addNewLineBetweenStatementsInBlocks;
+            BreakSprocParametersPerLine.IsChecked = settings.breakSprocParametersPerLine;
+            UppercaseBuiltInFunctions.IsChecked = settings.uppercaseBuiltInFunctions;
+            UnindentBeginEndBlocks.IsChecked = settings.unindentBeginEndBlocks;
+            BreakVariableDefinitionsPerLine.IsChecked = settings.breakVariableDefinitionsPerLine;
+            BreakSprocDefinitionParametersPerLine.IsChecked = settings.breakSprocDefinitionParametersPerLine;
+            LeadingCommas.IsChecked = settings.leadingCommas;
+            SemicolonBeforeCte.IsChecked = settings.semicolonBeforeCte;
+            BreakSelectElementsPerLine.IsChecked = settings.breakSelectElementsPerLine;
+            UseAssignmentAliases.IsChecked = settings.useAssignmentAliases;
+            OmitAsForTableAliases.IsChecked = settings.omitAsForTableAliases;
+            OmitAsInDeclare.IsChecked = settings.omitAsInDeclare;
+            FormatTableDefinitionsMultiline.IsChecked = settings.formatTableDefinitionsMultiline;
+            PrefixUnicodeStrings.IsChecked = settings.prefixUnicodeStrings;
+        }
+
+        private SettingsManager.TSqlCodeFormatSettings LearnTSqlFormatSettingsFromSample(string formattedSample)
+        {
+            string sql = formattedSample ?? string.Empty;
+            string normalized = NormalizeLineEndings(sql);
+            string codeOnly = StripCommentsForLearning(normalized);
+
+            return new SettingsManager.TSqlCodeFormatSettings
+            {
+                preserveComments = Regex.IsMatch(normalized, @"(?m)^\s*(--|/\*)"),
+                removeNewLineAfterJoin = Regex.IsMatch(codeOnly, @"(?is)\bJOIN\s+(?!\r?\n)\S.+?\s+ON\b"),
+                addTabAfterJoinOn = Regex.IsMatch(codeOnly, @"(?im)^\s{4,}ON\b"),
+                moveCrossJoinToNewLine = Regex.IsMatch(codeOnly, @"(?im)^\s*(CROSS\s+JOIN|OUTER\s+APPLY|CROSS\s+APPLY)\b"),
+                formatCaseAsMultiline = Regex.IsMatch(codeOnly, @"(?is)\bCASE\s*\r?\n\s+WHEN\b")
+                    || Regex.IsMatch(codeOnly, @"(?is)\bWHEN\b.+?\r?\n\s+THEN\b"),
+                addNewLineBetweenStatementsInBlocks = Regex.IsMatch(codeOnly, @";\s*(\r?\n){2,}\s*(SELECT|EXEC|DECLARE|IF|BEGIN|END)\b", RegexOptions.IgnoreCase),
+                breakSprocParametersPerLine = Regex.IsMatch(codeOnly, @"(?is)\bEXEC(?:UTE)?\s+[\[\]\w.]+\s*\r?\n\s*,?\s*@\w+.+\r?\n\s*,?\s*@\w+"),
+                uppercaseBuiltInFunctions = Regex.IsMatch(codeOnly, @"\b(GETDATE|DATEADD|COUNT|SUM)\s*\(")
+                    && !Regex.IsMatch(codeOnly, @"\b(getdate|dateadd|count|sum)\s*\("),
+                unindentBeginEndBlocks = Regex.IsMatch(codeOnly, @"(?m)^BEGIN\s*$")
+                    && Regex.IsMatch(codeOnly, @"(?m)^END\s*$"),
+                breakVariableDefinitionsPerLine = Regex.IsMatch(codeOnly, @"(?is)\bDECLARE\s+@\w+.+\r?\n\s*,?\s*@\w+"),
+                breakSprocDefinitionParametersPerLine = Regex.IsMatch(codeOnly, @"(?is)\bPROCEDURE\s+[\[\]\w.]+\s*\r?\n\s*,?\s*@\w+.+\r?\n\s*,?\s*@\w+"),
+                leadingCommas = Regex.IsMatch(codeOnly, @"(?m)^\s*,\s*\S"),
+                semicolonBeforeCte = Regex.IsMatch(codeOnly, @"(?im)^\s*;\s*WITH\b"),
+                breakSelectElementsPerLine = Regex.IsMatch(codeOnly, @"(?im)^\s*SELECT(?:\s+TOP\s+\d+)?\s*$")
+                    || Regex.IsMatch(codeOnly, @"(?m)^\s*,\s*[\w@]"),
+                useAssignmentAliases = Regex.IsMatch(codeOnly, @"(?m)^\s*,?\s*\w+\s*=\s*"),
+                omitAsForTableAliases = Regex.IsMatch(codeOnly, @"(?i)\b(FROM|JOIN|APPLY)\s+@\w+\s+\w+\b")
+                    && !Regex.IsMatch(codeOnly, @"(?i)\b(FROM|JOIN|APPLY)\s+@\w+\s+AS\s+\w+\b"),
+                omitAsInDeclare = Regex.IsMatch(codeOnly, @"(?im)^\s*DECLARE\s+@\w+\s+(?!AS\b)\w+"),
+                formatTableDefinitionsMultiline = Regex.IsMatch(codeOnly, @"(?is)\bDECLARE\s+@\w+\s+TABLE\s*\(\s*\r?\n"),
+                prefixUnicodeStrings = Regex.IsMatch(codeOnly, @"(?<![A-Za-z])N'"),
+                removeSemicolonsFromDeclare = Regex.IsMatch(codeOnly, @"(?im)^\s*DECLARE\s+@\w+.*[^;]\s*$")
+            };
+        }
+
+        private static string StripCommentsForLearning(string sql)
+        {
+            string withoutBlockComments = Regex.Replace(sql ?? string.Empty, @"/\*.*?\*/", string.Empty, RegexOptions.Singleline);
+            return Regex.Replace(withoutBlockComments, @"(?m)--.*$", string.Empty);
+        }
+
+        private bool ValidateFreehandFormatSample()
+        {
+            try
+            {
+                var learnedSettings = LearnTSqlFormatSettingsFromSample(FreehandFormatEditor.Text);
+                string learnedSourceFormat = TSqlFormatter.FormatCode(FreehandSourceEditor.Text, learnedSettings);
+                string sourceCanonical = CanonicalizeSqlForEquivalence(learnedSourceFormat);
+                string formattedCanonical = CanonicalizeSqlForEquivalence(FreehandFormatEditor.Text);
+
+                if (string.Equals(sourceCanonical, formattedCanonical, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+
+                MessageBox.Show(
+                    "The formatted sample must contain the same SQL as the source sample. You can change whitespace, casing, comments, comma placement, and semicolon placement, but not add, remove, or rewrite SQL.",
+                    "Format sample changed SQL",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    $"The formatted sample could not be parsed as valid T-SQL:{Environment.NewLine}{ex.Message}",
+                    "Format sample parse error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+            }
+
+            return false;
+        }
+
+        private static string CanonicalizeSqlForEquivalence(string sql)
+        {
+            TSql170Parser sqlParser = new TSql170Parser(false);
+            IList<ParseError> parseErrors;
+            TSqlFragment fragment = sqlParser.Parse(new StringReader(sql ?? string.Empty), out parseErrors);
+
+            if (parseErrors.Count > 0)
+            {
+                throw new Exception(BuildParseErrorMessage(parseErrors));
+            }
+
+            StringBuilder result = new StringBuilder();
+            foreach (var token in fragment.ScriptTokenStream)
+            {
+                if (!IsSignificantSqlToken(token))
+                {
+                    continue;
+                }
+
+                if (result.Length > 0)
+                {
+                    result.Append('\n');
+                }
+
+                result.Append(NormalizeSqlTokenType(token));
+                result.Append(':');
+                result.Append(NormalizeSqlTokenText(token));
+            }
+
+            return result.ToString();
+        }
+
+        private static bool IsSignificantSqlToken(TSqlParserToken token)
+        {
+            if (token == null || string.IsNullOrEmpty(token.Text))
+            {
+                return false;
+            }
+
+            return token.TokenType != TSqlTokenType.WhiteSpace
+                && token.TokenType != TSqlTokenType.SingleLineComment
+                && token.TokenType != TSqlTokenType.MultilineComment
+                && token.TokenType != TSqlTokenType.Semicolon
+                && token.Text != ";";
+        }
+
+        private static string NormalizeSqlTokenType(TSqlParserToken token)
+        {
+            if (token.TokenType == TSqlTokenType.AsciiStringLiteral
+                || token.TokenType == TSqlTokenType.UnicodeStringLiteral)
+            {
+                return "StringLiteral";
+            }
+
+            return token.TokenType.ToString();
+        }
+
+        private static string NormalizeSqlTokenText(TSqlParserToken token)
+        {
+            if (token.TokenType == TSqlTokenType.UnicodeStringLiteral
+                && token.Text.Length > 1
+                && char.ToUpperInvariant(token.Text[0]) == 'N'
+                && token.Text[1] == '\'')
+            {
+                return token.Text.Substring(1);
+            }
+
+            if (token.TokenType == TSqlTokenType.AsciiStringLiteral
+                || token.TokenType == TSqlTokenType.UnicodeStringLiteral
+                || token.TokenType == TSqlTokenType.Integer
+                || token.TokenType == TSqlTokenType.Real
+                || token.TokenType == TSqlTokenType.HexLiteral)
+            {
+                return token.Text;
+            }
+
+            return token.Text.ToUpperInvariant();
+        }
+
+        private static string BuildParseErrorMessage(IList<ParseError> parseErrors)
+        {
+            StringBuilder errorBuilder = new StringBuilder();
+            foreach (var parseError in parseErrors)
+            {
+                errorBuilder.AppendLine($"Line {parseError.Line}, column {parseError.Column}: {parseError.Message}");
+            }
+
+            return errorBuilder.ToString().Trim();
+        }
+
+        private static string NormalizeLineEndings(string text)
+        {
+            return (text ?? string.Empty).Replace("\r\n", "\n").Replace("\r", "\n").Replace("\n", "\r\n");
+        }
+
+        private void UpdateFormatModeUi()
+        {
+            if (FormatOptionsPanel == null || FreehandFormatPanel == null || FormatPreviewPanel == null)
+            {
+                return;
+            }
+
+            bool isFreehand = FormatModeFreehand.IsChecked == true;
+            FormatOptionsPanel.Visibility = isFreehand ? Visibility.Collapsed : Visibility.Visible;
+            FormatPreviewPanel.Visibility = isFreehand ? Visibility.Collapsed : Visibility.Visible;
+            FreehandFormatPanel.Visibility = isFreehand ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        private void formatTSqlExample()
+        {
+            if (SourceQueryPreview == null || FormattedQueryPreview == null)
+            {
+                return;
+            }
+
+            var settings = BuildTSqlCodeFormatSettingsFromUi();
 
             FormattedQueryPreview.Text = TSqlFormatter.FormatCode(SourceQueryPreview.Text, settings);
         }
@@ -680,6 +904,40 @@ as select 1;
         private void formatSetting_Unchecked(object sender, RoutedEventArgs e)
         {
             formatTSqlExample();
+        }
+
+        private void FormatMode_Checked(object sender, RoutedEventArgs e)
+        {
+            UpdateFormatModeUi();
+        }
+
+        private void Button_FormatFreehandSample_Click(object sender, RoutedEventArgs e)
+        {
+            FreehandFormatEditor.Text = TSqlFormatter.FormatCode(FreehandSourceEditor.Text, SettingsManager.GetTSqlCodeFormatSettings());
+        }
+
+        private void Button_OpenFreehandSampleInNewTab_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                ServiceCache.ScriptFactory.CreateNewBlankScript(ScriptType.Sql);
+
+                EnvDTE.DTE dte = Microsoft.VisualStudio.Shell.Package.GetGlobalService(typeof(EnvDTE.DTE)) as EnvDTE.DTE;
+                if (dte?.ActiveDocument == null)
+                {
+                    return;
+                }
+
+                EnvDTE.TextSelection selection = dte.ActiveDocument.Selection as EnvDTE.TextSelection;
+                if (selection != null)
+                {
+                    selection.Insert(FreehandFormatEditor.Text);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Unable to open the sample in a new SQL tab: {ex.Message}", "Open SQL tab");
+            }
         }
 
         private void buttonSaveGitHubSettings_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Add a way to "Learn from example" so the user just formats the example how they like and press save instead of checking a bunch of different check boxes.

- I think this approach is a lot more intuitive.
- Still support the old way.
- Adds new options that I needed to make it format how I like.